### PR TITLE
Add unit tests for design state behavior

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,13 @@
+import textwrap
+import uuid
+from pathlib import Path
+
+import pytest
+from systemrdl import RDLCompiler
+
+from peakrdl_busdecoder.udps import ALL_UDPS
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--sim-tool",
@@ -45,3 +55,35 @@ def pytest_addoption(parser):
         auto: choose the best tool based on what is installed
         """,
     )
+
+
+@pytest.fixture
+def rdl_compile(tmp_path):
+    """Compile SystemRDL source text and return the elaborated top addrmap."""
+
+    udp_dir = Path(__file__).resolve().parents[1] / "hdl-src"
+    for candidate in ("busdecoder_udps.rdl", "regblock_udps.rdl"):
+        udp_file = udp_dir / candidate
+        if udp_file.exists():
+            break
+    else:
+        raise FileNotFoundError(
+            "Unable to locate UDP definition file. Expected one of"
+            f" {', '.join(str(udp_dir / name) for name in ('busdecoder_udps.rdl', 'regblock_udps.rdl'))}."
+        )
+
+    def _compile(source: str, top: str, inst_name: str = "top", params: dict | None = None):
+        rdl_path = tmp_path / f"{uuid.uuid4().hex}.rdl"
+        rdl_path.write_text(textwrap.dedent(source))
+
+        rdlc = RDLCompiler()
+        for udp in ALL_UDPS:
+            rdlc.register_udp(udp)
+
+        rdlc.compile_file(str(udp_file))
+        rdlc.compile_file(str(rdl_path))
+
+        root = rdlc.elaborate(top, inst_name, params or {})
+        return root.top
+
+    return _compile

--- a/tests/unit/test_design_state.py
+++ b/tests/unit/test_design_state.py
@@ -1,0 +1,133 @@
+import textwrap
+
+import pytest
+from systemrdl.messages import RDLCompileError
+
+from peakrdl_busdecoder.design_state import DesignState
+from peakrdl_busdecoder.utils import clog2
+
+
+def test_minimal_map_infers_width_and_names(rdl_compile):
+    top = rdl_compile(
+        """
+        addrmap minimal {
+            reg {
+                field {sw=rw; hw=r;} value[31:0] = 0;
+            } reg0 @ 0x0;
+        };
+        """,
+        top="minimal",
+        inst_name="package",
+    )
+
+    ds = DesignState(top, {})
+
+    assert ds.cpuif_data_width == 32
+    expected_addr_width = max(clog2(top.size), clog2(ds.cpuif_data_width // 8) + 1)
+    assert ds.addr_width == expected_addr_width
+    assert ds.module_name == "package_"
+    assert ds.package_name == "package__pkg"
+
+
+def test_external_only_design_uses_warning_defaults(rdl_compile):
+    top = rdl_compile(
+        """
+        addrmap ext_only {
+            reg shell_reg {
+                field {sw=rw; hw=r;} value[31:0] = 0;
+            };
+
+            external shell_reg ext_reg @ 0x0;
+            external regfile {
+                reg {
+                    field {sw=rw; hw=r;} value[31:0] = 0;
+                } r0 @ 0x0;
+            } ext_rf @ 0x100;
+
+            external addrmap {
+                reg {
+                    field {sw=rw; hw=r;} value[31:0] = 0;
+                } r0 @ 0x0;
+            } ext_map @ 0x200;
+        };
+        """,
+        top="ext_only",
+    )
+
+    ds = DesignState(top, {})
+
+    assert ds.cpuif_data_width == 32
+    assert ds.has_external_addressable is True
+    assert ds.has_external_block is True
+
+
+def test_address_width_override_validation(rdl_compile):
+    design_src = textwrap.dedent(
+        """
+        addrmap override_test {
+            reg {
+                field {sw=rw; hw=r;} value[31:0] = 0;
+            } r0 @ 0x0;
+            reg {
+                field {sw=rw; hw=r;} value[31:0] = 0;
+            } r1 @ 0x4;
+        };
+        """
+    )
+
+    top = rdl_compile(design_src, top="override_test")
+
+    base_ds = DesignState(top, {})
+
+    with pytest.raises(RDLCompileError):
+        DesignState(
+            rdl_compile(design_src, top="override_test"),
+            {"address_width": base_ds.addr_width - 1},
+        )
+
+    widened_ds = DesignState(
+        rdl_compile(design_src, top="override_test"),
+        {"address_width": base_ds.addr_width + 2},
+    )
+    assert widened_ds.addr_width == base_ds.addr_width + 2
+
+
+@pytest.mark.parametrize(
+    "external_decl",
+    [
+        """
+        external regfile {
+            reg {
+                field {sw=rw; hw=r;} value[31:0] = 0;
+            } r0 @ 0x0;
+        } ext_rf @ 0x100;
+        """,
+        """
+        external addrmap {
+            reg {
+                field {sw=rw; hw=r;} value[31:0] = 0;
+            } r0 @ 0x0;
+        } ext_map @ 0x100;
+        """,
+    ],
+    ids=["regfile", "addrmap"],
+)
+def test_design_scanner_marks_external_blocks(rdl_compile, external_decl):
+    external_block = textwrap.indent(textwrap.dedent(external_decl).strip(), "    ")
+    source = textwrap.dedent(
+        """
+        addrmap top {
+            reg {
+                field {sw=rw; hw=r;} value[31:0] = 0;
+            } r0 @ 0x0;
+        %s
+        };
+        """
+        % external_block
+    )
+
+    top = rdl_compile(source, top="top")
+    ds = DesignState(top, {})
+
+    assert ds.has_external_addressable is True
+    assert ds.has_external_block is True


### PR DESCRIPTION
## Summary
- add an `rdl_compile` fixture that compiles inline SystemRDL sources for tests
- cover key `DesignState` and `DesignScanner` scenarios with new unit tests
- update the fixture and tests to handle renamed UDP definition files and avoid stale compiler state during address-width override checks

## Testing
- pytest tests/unit/test_design_state.py

------
https://chatgpt.com/codex/tasks/task_e_68f577948d448325ab9d41f7ba7f74d4