### PR TITLE
Change required systemrdl-compiler verison to ~1.31 to match peakrdl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "peakrdl-busdecoder"
-version = "0.5.0"
+version = "0.6.0"
 requires-python = ">=3.10"
-dependencies = ["jinja2>=3.1.6", "systemrdl-compiler~=1.30.1"]
+dependencies = ["jinja2>=3.1.6", "systemrdl-compiler~=1.31"]
 
 authors = [{ name = "Arnav Sacheti" }]
 description = "Generate a SystemVerilog bus decoder from SystemRDL for splitting CPU interfaces to multiple sub-address spaces"


### PR DESCRIPTION
Bump systemrdl-compiler version to 1.31 to match the rest of the peakrdl suite. If you don't do this, you cannot install this package and the PeakRDL packages at the same time.