### PR TITLE
Add VS Code extension scaffold

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "peakrdl-busdecoder",
+  "displayName": "PeakRDL BusDecoder",
+  "description": "VS Code extension scaffold for PeakRDL BusDecoder.",
+  "version": "0.0.1",
+  "publisher": "peakrdl",
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "main": "dist/extension.js",
+  "activationEvents": [
+    "onCommand:peakrdl-busdecoder.hello"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "peakrdl-busdecoder.hello",
+        "title": "PeakRDL BusDecoder: Hello"
+      }
+    ]
+  },
+  "scripts": {
+    "build": "webpack --mode production",
+    "watch": "webpack --mode development --watch"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.80.0",
+    "ts-loader": "^9.5.0",
+    "typescript": "^5.4.0",
+    "webpack": "^5.90.0",
+    "webpack-cli": "^5.1.4"
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,16 @@
+import * as vscode from "vscode";
+
+export function activate(context: vscode.ExtensionContext): void {
+  const disposable = vscode.commands.registerCommand(
+    "peakrdl-busdecoder.hello",
+    () => {
+      vscode.window.showInformationMessage("PeakRDL BusDecoder is ready.");
+    }
+  );
+
+  context.subscriptions.push(disposable);
+}
+
+export function deactivate(): void {
+  // no-op
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "rootDir": "src",
+    "strict": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,36 @@
+const path = require("path");
+
+module.exports = {
+  target: "node",
+  entry: "./src/extension.ts",
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: "extension.js",
+    libraryTarget: "commonjs2"
+  },
+  resolve: {
+    extensions: [".ts", ".js"]
+  },
+  externals: {
+    vscode: "commonjs vscode"
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: "ts-loader",
+            options: {
+              compilerOptions: {
+                sourceMap: true
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  devtool: "source-map"
+};


### PR DESCRIPTION
### Motivation
- Provide a minimal VS Code extension scaffold to expose the BusDecoder functionality as an extension.
- Ensure the extension has a packaged entry point at `dist/extension.js` and a declared `engines.vscode` version.
- Add a TypeScript-based build pipeline so the extension can be bundled for publishing.
- Provide convenient `npm` scripts for iterative development and production builds.

### Description
- Add `package.json` with `engines.vscode`, `main: "dist/extension.js"`, `activationEvents`, `contributes` (a `peakrdl-busdecoder.hello` command), and `scripts` for `build` and `watch`.
- Add `src/extension.ts` exporting `activate` and `deactivate` and registering the `peakrdl-busdecoder.hello` command which shows an information message.
- Add `tsconfig.json` with compiler options targeting `ES2020`, `commonjs` module, and `src` as `rootDir`.
- Add `webpack.config.js` to bundle `./src/extension.ts` into `dist/extension.js` using `ts-loader` and mark `vscode` as external.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948b03f6e5c8325baade52994f9ae03)