### PR TITLE
Add comprehensive protocol tests and stress test suite

### DIFF
--- a/tests/cocotb/apb3/smoke/test_register_access.py
+++ b/tests/cocotb/apb3/smoke/test_register_access.py
@@ -9,10 +9,12 @@ from cocotb.triggers import RisingEdge, Timer
 
 from tests.cocotb_lib.handle_utils import make_signal_handle
 from tests.cocotb_lib.protocol_utils import (
+    advance,
     all_index_pairs,
     find_invalid_address,
     get_int,
     load_config,
+    pick_distinct_pairs,
     set_value,
     start_clock,
 )
@@ -83,6 +85,22 @@ def _write_pattern(address: int, width: int) -> int:
 def _read_pattern(address: int, width: int) -> int:
     mask = (1 << width) - 1
     return ((address ^ 0x0BAD_F00D) + width) & mask
+
+
+def _idle_slave(slave) -> None:
+    slave.PSEL.value = 0
+    slave.PENABLE.value = 0
+    slave.PWRITE.value = 0
+    slave.PADDR.value = 0
+    slave.PWDATA.value = 0
+
+
+def _idle_masters(masters) -> None:
+    for master_name, idx in all_index_pairs(masters):
+        entry = masters[master_name]
+        set_value(entry["inputs"]["PRDATA"], idx, 0)
+        set_value(entry["inputs"]["PREADY"], idx, 0)
+        set_value(entry["inputs"]["PSLVERR"], idx, 0)
 
 
 @cocotb.test()
@@ -353,3 +371,222 @@ async def test_apb3_invalid_address_response(dut) -> None:
 
     assert int(slave.PREADY.value) == 1, "Invalid address should still complete the transfer"
     assert int(slave.PSLVERR.value) == 1, "Invalid address should raise PSLVERR"
+
+
+@cocotb.test()
+async def test_apb3_reset_quiescent(dut) -> None:
+    """With the slave idle, no master should see PSEL asserted."""
+    config = load_config()
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _Apb3SlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    await start_clock(slave.PCLK)
+
+    # Hold reset low first (if present) and verify no master gets selected.
+    if slave.PRESETn is not None:
+        slave.PRESETn.value = 0
+    _idle_slave(slave)
+    _idle_masters(masters)
+
+    await advance(slave.PCLK)
+
+    for master_name, idx in all_index_pairs(masters):
+        entry = masters[master_name]
+        assert get_int(entry["outputs"]["PSEL"], idx) == 0, (
+            f"{master_name}{idx} must be idle while bus is quiescent"
+        )
+        assert get_int(entry["outputs"]["PENABLE"], idx) == 0, (
+            f"{master_name}{idx} must hold PENABLE low while bus is quiescent"
+        )
+
+    # Deassert reset and re-check.
+    if slave.PRESETn is not None:
+        slave.PRESETn.value = 1
+    await advance(slave.PCLK)
+
+    for master_name, idx in all_index_pairs(masters):
+        entry = masters[master_name]
+        assert get_int(entry["outputs"]["PSEL"], idx) == 0, (
+            f"{master_name}{idx} must remain idle with PSEL low after reset release"
+        )
+
+
+@cocotb.test()
+async def test_apb3_setup_access_stability(dut) -> None:
+    """Master-side command signals must stay stable across multi-cycle access phases."""
+    config = load_config()
+    if not config["transactions"]:
+        dut._log.warning("No transactions available; skipping stability test")
+        return
+
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _Apb3SlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    await start_clock(slave.PCLK)
+    if slave.PRESETn is not None:
+        slave.PRESETn.value = 1
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await advance(slave.PCLK)
+
+    txn = config["transactions"][0]
+    entry = masters[txn["master"]]
+    index = tuple(txn["index"])
+    address = txn["address"] & ((1 << config["address_width"]) - 1)
+    write_data = _write_pattern(address, config["data_width"])
+    master_address = (address - entry["inst_address"]) % entry["inst_size"]
+
+    # Setup phase
+    slave.PADDR.value = address
+    slave.PWDATA.value = write_data
+    slave.PWRITE.value = 1
+    slave.PSEL.value = 1
+    slave.PENABLE.value = 0
+    await advance(slave.PCLK)
+
+    # Access phase, but master stalls PREADY for several cycles.
+    slave.PENABLE.value = 1
+    wait_states = 3
+    for wait in range(wait_states):
+        await advance(slave.PCLK)
+        assert get_int(entry["outputs"]["PSEL"], index) == 1, (
+            f"PSEL must stay high during wait cycle {wait}"
+        )
+        assert get_int(entry["outputs"]["PENABLE"], index) == 1, (
+            f"PENABLE must stay high during wait cycle {wait}"
+        )
+        assert get_int(entry["outputs"]["PWRITE"], index) == 1, (
+            f"PWRITE must remain stable during wait cycle {wait}"
+        )
+        assert get_int(entry["outputs"]["PADDR"], index) == master_address, (
+            f"PADDR must remain stable during wait cycle {wait}"
+        )
+        assert get_int(entry["outputs"]["PWDATA"], index) == write_data, (
+            f"PWDATA must remain stable during wait cycle {wait}"
+        )
+        assert int(slave.PREADY.value) == 0, (
+            f"Slave PREADY must remain low while master stalls at wait {wait}"
+        )
+
+    # Release the wait, transfer completes.
+    set_value(entry["inputs"]["PREADY"], index, 1)
+    await advance(slave.PCLK)
+    assert int(slave.PREADY.value) == 1, "Slave PREADY must follow master once released"
+    assert int(slave.PSLVERR.value) == 0, "No slave error expected"
+
+
+@cocotb.test()
+async def test_apb3_back_to_back(dut) -> None:
+    """Two successive transfers to distinct masters must each complete cleanly."""
+    config = load_config()
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _Apb3SlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    pair = pick_distinct_pairs(config["transactions"], count=2)
+    if len(pair) < 2:
+        dut._log.warning("Need at least two distinct master/index transactions; skipping")
+        return
+
+    await start_clock(slave.PCLK)
+    if slave.PRESETn is not None:
+        slave.PRESETn.value = 1
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await advance(slave.PCLK)
+
+    addr_mask = (1 << config["address_width"]) - 1
+
+    for txn in pair:
+        entry = masters[txn["master"]]
+        index = tuple(txn["index"])
+        address = txn["address"] & addr_mask
+        write_data = _write_pattern(address, config["data_width"])
+        master_address = (address - entry["inst_address"]) % entry["inst_size"]
+
+        set_value(entry["inputs"]["PREADY"], index, 1)
+
+        # Setup
+        slave.PADDR.value = address
+        slave.PWDATA.value = write_data
+        slave.PWRITE.value = 1
+        slave.PSEL.value = 1
+        slave.PENABLE.value = 0
+        await advance(slave.PCLK)
+        assert get_int(entry["outputs"]["PSEL"], index) == 1, (
+            f"{txn['master']}{index} should be selected in setup"
+        )
+        assert get_int(entry["outputs"]["PADDR"], index) == master_address, (
+            f"{txn['master']}{index} must receive its local address"
+        )
+
+        # Access
+        slave.PENABLE.value = 1
+        await advance(slave.PCLK)
+        assert int(slave.PREADY.value) == 1, "Slave must see PREADY when target is ready"
+
+        # Other masters should never be selected during this transfer.
+        for other_name, other_idx in all_index_pairs(masters):
+            if other_name == txn["master"] and other_idx == index:
+                continue
+            other_entry = masters[other_name]
+            assert get_int(other_entry["outputs"]["PSEL"], other_idx) == 0, (
+                f"{other_name}{other_idx} should remain idle during {txn['label']}"
+            )
+
+        # Release PREADY on the first master so the next transfer is unambiguous,
+        # but keep PSEL high only during the zero-idle transition cycle.
+        set_value(entry["inputs"]["PREADY"], index, 0)
+        slave.PSEL.value = 0
+        slave.PENABLE.value = 0
+
+
+@cocotb.test()
+async def test_apb3_slave_error_passthrough(dut) -> None:
+    """Slave-side PSLVERR from the target master must surface on the bus."""
+    config = load_config()
+    if not config["transactions"]:
+        dut._log.warning("No transactions available; skipping slave error test")
+        return
+
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _Apb3SlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    await start_clock(slave.PCLK)
+    if slave.PRESETn is not None:
+        slave.PRESETn.value = 1
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await advance(slave.PCLK)
+
+    txn = config["transactions"][0]
+    entry = masters[txn["master"]]
+    index = tuple(txn["index"])
+    address = txn["address"] & ((1 << config["address_width"]) - 1)
+
+    set_value(entry["inputs"]["PREADY"], index, 1)
+    set_value(entry["inputs"]["PSLVERR"], index, 1)
+
+    slave.PADDR.value = address
+    slave.PWDATA.value = _write_pattern(address, config["data_width"])
+    slave.PWRITE.value = 1
+    slave.PSEL.value = 1
+    slave.PENABLE.value = 0
+    await advance(slave.PCLK)
+
+    slave.PENABLE.value = 1
+    await advance(slave.PCLK)
+
+    assert int(slave.PREADY.value) == 1, "Bus PREADY must mirror master PREADY"
+    assert int(slave.PSLVERR.value) == 1, "Bus PSLVERR must mirror master PSLVERR"
+
+    for other_name, other_idx in all_index_pairs(masters):
+        if other_name == txn["master"] and other_idx == index:
+            continue
+        other_entry = masters[other_name]
+        assert get_int(other_entry["outputs"]["PSEL"], other_idx) == 0, (
+            f"{other_name}{other_idx} must remain idle during error response"
+        )

--- a/tests/cocotb/apb3/smoke/test_runner_stress.py
+++ b/tests/cocotb/apb3/smoke/test_runner_stress.py
@@ -1,0 +1,87 @@
+"""Pytest wrapper launching the APB3 cocotb stress tests (exhaustive address coverage)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+from peakrdl_busdecoder.cpuif.apb3.apb3_cpuif import APB3CpuifFlat
+
+try:  # pragma: no cover - optional dependency shim
+    from cocotb.runner import get_runner
+except ImportError:  # pragma: no cover
+    from cocotb_tools.runner import get_runner
+
+from tests.cocotb_lib import RDL_CASES
+from tests.cocotb_lib.utils import colorize_cocotb_log, get_verilog_sources, prepare_cpuif_case
+
+
+@pytest.mark.simulation
+@pytest.mark.verilator
+@pytest.mark.parametrize(("rdl_file", "top_name"), RDL_CASES, ids=[case[1] for case in RDL_CASES])
+def test_apb3_stress(tmp_path: Path, rdl_file: str, top_name: str) -> None:
+    """Generate each APB3 design variant and run the randomized stress sequence."""
+    repo_root = Path(__file__).resolve().parents[4]
+    rdl_path = repo_root / "tests" / "cocotb_lib" / "rdl" / rdl_file
+    build_root = tmp_path / top_name
+
+    module_path, package_path, config = prepare_cpuif_case(
+        str(rdl_path),
+        top_name,
+        build_root,
+        cpuif_cls=APB3CpuifFlat,
+        control_signal="PSEL",
+        max_samples_per_master=0,
+    )
+
+    sources = get_verilog_sources(
+        module_path,
+        package_path,
+        [repo_root / "hdl-src" / "apb3_intf.sv"],
+    )
+
+    runner = get_runner("verilator")
+    sim_build = build_root / "sim_build"
+
+    build_log_file = build_root / "build.log"
+    sim_log_file = build_root / "simulation.log"
+
+    try:
+        runner.build(
+            sources=sources,
+            hdl_toplevel=module_path.stem,
+            build_dir=sim_build,
+            log_file=str(build_log_file),
+        )
+    except SystemExit as e:
+        if build_log_file.exists():
+            logging.error(f"""
+=== Build Log ===
+{colorize_cocotb_log(build_log_file.read_text())}
+=== End Build Log ===
+""")
+        if e.code != 0:
+            raise
+
+    try:
+        runner.test(
+            hdl_toplevel=module_path.stem,
+            test_module="tests.cocotb.apb3.smoke.test_stress",
+            build_dir=sim_build,
+            log_file=str(sim_log_file),
+            extra_env={
+                "RDL_TEST_CONFIG": json.dumps(config),
+                "RDL_TEST_SEED": "0xC0C07B",
+            },
+        )
+    except SystemExit as e:
+        if sim_log_file.exists():
+            logging.error(f"""
+=== Simulation Log ===
+{colorize_cocotb_log(sim_log_file.read_text())}
+=== End Simulation Log ===
+""")
+        if e.code != 0:
+            raise

--- a/tests/cocotb/apb3/smoke/test_stress.py
+++ b/tests/cocotb/apb3/smoke/test_stress.py
@@ -1,0 +1,137 @@
+"""APB3 stress tests: long randomized transaction streams with write/read-back checks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import cocotb
+
+from tests.cocotb.apb3.smoke.test_register_access import (
+    _Apb3SlaveShim,
+    _build_master_table,
+    _idle_masters,
+    _idle_slave,
+    _write_pattern,
+)
+from tests.cocotb_lib.protocol_utils import (
+    advance,
+    load_config,
+    make_rng,
+    set_value,
+    shuffle_transactions,
+    start_clock,
+)
+
+
+async def _apb3_write(
+    slave: _Apb3SlaveShim,
+    entry: dict[str, Any],
+    index: tuple[int, ...],
+    address: int,
+    data: int,
+    ready_delay: int,
+) -> None:
+    set_value(entry["inputs"]["PSLVERR"], index, 0)
+    set_value(entry["inputs"]["PREADY"], index, 0)
+
+    slave.PADDR.value = address
+    slave.PWDATA.value = data
+    slave.PWRITE.value = 1
+    slave.PSEL.value = 1
+    slave.PENABLE.value = 0
+    await advance(slave.PCLK)
+
+    slave.PENABLE.value = 1
+    for _ in range(ready_delay):
+        await advance(slave.PCLK)
+
+    set_value(entry["inputs"]["PREADY"], index, 1)
+    await advance(slave.PCLK)
+
+    slave.PSEL.value = 0
+    slave.PENABLE.value = 0
+    slave.PWRITE.value = 0
+    set_value(entry["inputs"]["PREADY"], index, 0)
+    await advance(slave.PCLK)
+
+
+async def _apb3_read(
+    slave: _Apb3SlaveShim,
+    entry: dict[str, Any],
+    index: tuple[int, ...],
+    address: int,
+    expected: int,
+    ready_delay: int,
+) -> None:
+    set_value(entry["inputs"]["PRDATA"], index, expected)
+    set_value(entry["inputs"]["PSLVERR"], index, 0)
+    set_value(entry["inputs"]["PREADY"], index, 0)
+
+    slave.PADDR.value = address
+    slave.PWRITE.value = 0
+    slave.PSEL.value = 1
+    slave.PENABLE.value = 0
+    await advance(slave.PCLK)
+
+    slave.PENABLE.value = 1
+    for _ in range(ready_delay):
+        await advance(slave.PCLK)
+
+    set_value(entry["inputs"]["PREADY"], index, 1)
+    await advance(slave.PCLK)
+    assert int(slave.PRDATA.value) == expected, (
+        f"Slave PRDATA mismatch at address 0x{address:x}: "
+        f"expected 0x{expected:x}, got 0x{int(slave.PRDATA.value):x}"
+    )
+    assert int(slave.PSLVERR.value) == 0, "Stress read should not raise PSLVERR"
+
+    slave.PSEL.value = 0
+    slave.PENABLE.value = 0
+    set_value(entry["inputs"]["PREADY"], index, 0)
+    set_value(entry["inputs"]["PRDATA"], index, 0)
+    await advance(slave.PCLK)
+
+
+@cocotb.test()
+async def test_apb3_random_traffic(dut) -> None:
+    """Drive every sampled register with write/read-back in a shuffled, jittered sequence."""
+    config = load_config()
+    if not config["transactions"]:
+        dut._log.warning("No transactions available; skipping stress run")
+        return
+
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _Apb3SlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    await start_clock(slave.PCLK)
+    if slave.PRESETn is not None:
+        slave.PRESETn.value = 1
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await advance(slave.PCLK)
+
+    rng = make_rng()
+    addr_mask = (1 << config["address_width"]) - 1
+    shadow: dict[tuple[str, tuple[int, ...], int], int] = {}
+
+    write_order = shuffle_transactions(config["transactions"], rng)
+    for txn in write_order:
+        entry = masters[txn["master"]]
+        index = tuple(txn["index"])
+        address = txn["address"] & addr_mask
+        data = _write_pattern(address, config["data_width"])
+        await _apb3_write(slave, entry, index, address, data, rng.randint(0, 2))
+        shadow[(txn["master"], index, address)] = data
+
+    read_order = shuffle_transactions(config["transactions"], rng)
+    for txn in read_order:
+        entry = masters[txn["master"]]
+        index = tuple(txn["index"])
+        address = txn["address"] & addr_mask
+        expected = shadow[(txn["master"], index, address)]
+        await _apb3_read(slave, entry, index, address, expected, rng.randint(0, 2))
+
+    dut._log.info(
+        f"APB3 stress: completed {len(write_order)} writes + {len(read_order)} reads"
+    )

--- a/tests/cocotb/apb4/smoke/test_register_access.py
+++ b/tests/cocotb/apb4/smoke/test_register_access.py
@@ -9,10 +9,12 @@ from cocotb.triggers import RisingEdge, Timer
 
 from tests.cocotb_lib.handle_utils import make_signal_handle
 from tests.cocotb_lib.protocol_utils import (
+    advance,
     all_index_pairs,
     find_invalid_address,
     get_int,
     load_config,
+    pick_distinct_pairs,
     set_value,
     start_clock,
 )
@@ -90,6 +92,24 @@ def _write_pattern(address: int, width: int) -> int:
 def _read_pattern(address: int, width: int) -> int:
     mask = (1 << width) - 1
     return ((address ^ 0xDEAD_BEE5) + width) & mask
+
+
+def _idle_slave(slave) -> None:
+    slave.PSEL.value = 0
+    slave.PENABLE.value = 0
+    slave.PWRITE.value = 0
+    slave.PADDR.value = 0
+    slave.PPROT.value = 0
+    slave.PWDATA.value = 0
+    slave.PSTRB.value = 0
+
+
+def _idle_masters(masters) -> None:
+    for master_name, idx in all_index_pairs(masters):
+        entry = masters[master_name]
+        set_value(entry["inputs"]["PRDATA"], idx, 0)
+        set_value(entry["inputs"]["PREADY"], idx, 0)
+        set_value(entry["inputs"]["PSLVERR"], idx, 0)
 
 
 @cocotb.test()
@@ -386,3 +406,289 @@ async def test_apb4_invalid_address_response(dut) -> None:
 
     assert int(slave.PREADY.value) == 1, "Invalid address should still complete the transfer"
     assert int(slave.PSLVERR.value) == 1, "Invalid address should raise PSLVERR"
+
+
+@cocotb.test()
+async def test_apb4_reset_quiescent(dut) -> None:
+    """With the slave idle, no master should see PSEL asserted."""
+    config = load_config()
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _Apb4SlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    await start_clock(slave.PCLK)
+    if slave.PRESETn is not None:
+        slave.PRESETn.value = 0
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await advance(slave.PCLK)
+
+    for master_name, idx in all_index_pairs(masters):
+        entry = masters[master_name]
+        assert get_int(entry["outputs"]["PSEL"], idx) == 0, (
+            f"{master_name}{idx} must be idle while bus is quiescent"
+        )
+        assert get_int(entry["outputs"]["PENABLE"], idx) == 0, (
+            f"{master_name}{idx} must hold PENABLE low while bus is quiescent"
+        )
+
+    if slave.PRESETn is not None:
+        slave.PRESETn.value = 1
+    await advance(slave.PCLK)
+
+    for master_name, idx in all_index_pairs(masters):
+        entry = masters[master_name]
+        assert get_int(entry["outputs"]["PSEL"], idx) == 0, (
+            f"{master_name}{idx} must remain idle after reset release"
+        )
+
+
+@cocotb.test()
+async def test_apb4_setup_access_stability(dut) -> None:
+    """Master-side command signals must stay stable across multi-cycle access phases."""
+    config = load_config()
+    if not config["transactions"]:
+        dut._log.warning("No transactions available; skipping stability test")
+        return
+
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _Apb4SlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    await start_clock(slave.PCLK)
+    if slave.PRESETn is not None:
+        slave.PRESETn.value = 1
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await advance(slave.PCLK)
+
+    txn = config["transactions"][0]
+    entry = masters[txn["master"]]
+    index = tuple(txn["index"])
+    address = txn["address"] & ((1 << config["address_width"]) - 1)
+    strobe_mask = (1 << config["byte_width"]) - 1
+    write_data = _write_pattern(address, config["data_width"])
+    master_address = (address - entry["inst_address"]) % entry["inst_size"]
+
+    # Setup phase
+    slave.PADDR.value = address
+    slave.PWDATA.value = write_data
+    slave.PSTRB.value = strobe_mask
+    slave.PPROT.value = 0
+    slave.PWRITE.value = 1
+    slave.PSEL.value = 1
+    slave.PENABLE.value = 0
+    await advance(slave.PCLK)
+
+    slave.PENABLE.value = 1
+    wait_states = 3
+    for wait in range(wait_states):
+        await advance(slave.PCLK)
+        assert get_int(entry["outputs"]["PSEL"], index) == 1, (
+            f"PSEL must stay high during wait cycle {wait}"
+        )
+        assert get_int(entry["outputs"]["PENABLE"], index) == 1, (
+            f"PENABLE must stay high during wait cycle {wait}"
+        )
+        assert get_int(entry["outputs"]["PWRITE"], index) == 1, (
+            f"PWRITE must remain stable during wait cycle {wait}"
+        )
+        assert get_int(entry["outputs"]["PADDR"], index) == master_address, (
+            f"PADDR must remain stable during wait cycle {wait}"
+        )
+        assert get_int(entry["outputs"]["PWDATA"], index) == write_data, (
+            f"PWDATA must remain stable during wait cycle {wait}"
+        )
+        assert get_int(entry["outputs"]["PSTRB"], index) == strobe_mask, (
+            f"PSTRB must remain stable during wait cycle {wait}"
+        )
+        assert int(slave.PREADY.value) == 0, (
+            f"Slave PREADY must remain low while master stalls at wait {wait}"
+        )
+
+    set_value(entry["inputs"]["PREADY"], index, 1)
+    await advance(slave.PCLK)
+    assert int(slave.PREADY.value) == 1, "Slave PREADY must follow master once released"
+    assert int(slave.PSLVERR.value) == 0, "No slave error expected"
+
+
+@cocotb.test()
+async def test_apb4_back_to_back(dut) -> None:
+    """Two successive transfers to distinct masters must each complete cleanly."""
+    config = load_config()
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _Apb4SlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    pair = pick_distinct_pairs(config["transactions"], count=2)
+    if len(pair) < 2:
+        dut._log.warning("Need at least two distinct master/index transactions; skipping")
+        return
+
+    await start_clock(slave.PCLK)
+    if slave.PRESETn is not None:
+        slave.PRESETn.value = 1
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await advance(slave.PCLK)
+
+    addr_mask = (1 << config["address_width"]) - 1
+    strobe_mask = (1 << config["byte_width"]) - 1
+
+    for txn in pair:
+        entry = masters[txn["master"]]
+        index = tuple(txn["index"])
+        address = txn["address"] & addr_mask
+        write_data = _write_pattern(address, config["data_width"])
+        master_address = (address - entry["inst_address"]) % entry["inst_size"]
+
+        set_value(entry["inputs"]["PREADY"], index, 1)
+
+        slave.PADDR.value = address
+        slave.PWDATA.value = write_data
+        slave.PSTRB.value = strobe_mask
+        slave.PWRITE.value = 1
+        slave.PSEL.value = 1
+        slave.PENABLE.value = 0
+        await advance(slave.PCLK)
+        assert get_int(entry["outputs"]["PSEL"], index) == 1, (
+            f"{txn['master']}{index} should be selected in setup"
+        )
+        assert get_int(entry["outputs"]["PADDR"], index) == master_address, (
+            f"{txn['master']}{index} must receive its local address"
+        )
+
+        slave.PENABLE.value = 1
+        await advance(slave.PCLK)
+        assert int(slave.PREADY.value) == 1, "Slave must see PREADY when target is ready"
+
+        for other_name, other_idx in all_index_pairs(masters):
+            if other_name == txn["master"] and other_idx == index:
+                continue
+            other_entry = masters[other_name]
+            assert get_int(other_entry["outputs"]["PSEL"], other_idx) == 0, (
+                f"{other_name}{other_idx} should remain idle during {txn['label']}"
+            )
+
+        set_value(entry["inputs"]["PREADY"], index, 0)
+        slave.PSEL.value = 0
+        slave.PENABLE.value = 0
+
+
+@cocotb.test()
+async def test_apb4_slave_error_passthrough(dut) -> None:
+    """Slave-side PSLVERR from the target master must surface on the bus."""
+    config = load_config()
+    if not config["transactions"]:
+        dut._log.warning("No transactions available; skipping slave error test")
+        return
+
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _Apb4SlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    await start_clock(slave.PCLK)
+    if slave.PRESETn is not None:
+        slave.PRESETn.value = 1
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await advance(slave.PCLK)
+
+    txn = config["transactions"][0]
+    entry = masters[txn["master"]]
+    index = tuple(txn["index"])
+    address = txn["address"] & ((1 << config["address_width"]) - 1)
+    strobe_mask = (1 << config["byte_width"]) - 1
+
+    set_value(entry["inputs"]["PREADY"], index, 1)
+    set_value(entry["inputs"]["PSLVERR"], index, 1)
+
+    slave.PADDR.value = address
+    slave.PWDATA.value = _write_pattern(address, config["data_width"])
+    slave.PSTRB.value = strobe_mask
+    slave.PWRITE.value = 1
+    slave.PSEL.value = 1
+    slave.PENABLE.value = 0
+    await advance(slave.PCLK)
+
+    slave.PENABLE.value = 1
+    await advance(slave.PCLK)
+
+    assert int(slave.PREADY.value) == 1, "Bus PREADY must mirror master PREADY"
+    assert int(slave.PSLVERR.value) == 1, "Bus PSLVERR must mirror master PSLVERR"
+
+    for other_name, other_idx in all_index_pairs(masters):
+        if other_name == txn["master"] and other_idx == index:
+            continue
+        other_entry = masters[other_name]
+        assert get_int(other_entry["outputs"]["PSEL"], other_idx) == 0, (
+            f"{other_name}{other_idx} must remain idle during error response"
+        )
+
+
+@cocotb.test()
+async def test_apb4_byte_strobes(dut) -> None:
+    """Exercise a spread of PSTRB values and verify the target master sees them intact."""
+    config = load_config()
+    if not config["transactions"]:
+        dut._log.warning("No transactions available; skipping PSTRB sweep")
+        return
+
+    byte_width = config["byte_width"]
+    full_mask = (1 << byte_width) - 1
+
+    # Build a small set of interesting strobe patterns for this data width.
+    strobe_set: list[int] = []
+    for base in (0x1, 0x2, 0x4, 0x8, 0xF, 0x5, 0xA):
+        masked = base & full_mask
+        if masked and masked not in strobe_set:
+            strobe_set.append(masked)
+    if full_mask not in strobe_set:
+        strobe_set.append(full_mask)
+
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _Apb4SlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    await start_clock(slave.PCLK)
+    if slave.PRESETn is not None:
+        slave.PRESETn.value = 1
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await advance(slave.PCLK)
+
+    txn = config["transactions"][0]
+    entry = masters[txn["master"]]
+    index = tuple(txn["index"])
+    address = txn["address"] & ((1 << config["address_width"]) - 1)
+    write_data = _write_pattern(address, config["data_width"])
+    master_address = (address - entry["inst_address"]) % entry["inst_size"]
+
+    for strobe in strobe_set:
+        set_value(entry["inputs"]["PREADY"], index, 1)
+        set_value(entry["inputs"]["PSLVERR"], index, 0)
+
+        slave.PADDR.value = address
+        slave.PWDATA.value = write_data
+        slave.PSTRB.value = strobe
+        slave.PWRITE.value = 1
+        slave.PSEL.value = 1
+        slave.PENABLE.value = 0
+        await advance(slave.PCLK)
+        assert get_int(entry["outputs"]["PSTRB"], index) == strobe, (
+            f"PSTRB 0x{strobe:x} must reach target master in setup"
+        )
+
+        slave.PENABLE.value = 1
+        await advance(slave.PCLK)
+        assert get_int(entry["outputs"]["PSTRB"], index) == strobe, (
+            f"PSTRB 0x{strobe:x} must remain stable in access"
+        )
+        assert get_int(entry["outputs"]["PADDR"], index) == master_address
+        assert get_int(entry["outputs"]["PWDATA"], index) == write_data
+        assert int(slave.PREADY.value) == 1
+
+        slave.PSEL.value = 0
+        slave.PENABLE.value = 0
+        set_value(entry["inputs"]["PREADY"], index, 0)
+        await advance(slave.PCLK)

--- a/tests/cocotb/apb4/smoke/test_runner_stress.py
+++ b/tests/cocotb/apb4/smoke/test_runner_stress.py
@@ -1,0 +1,87 @@
+"""Pytest wrapper launching the APB4 cocotb stress tests (exhaustive address coverage)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+from peakrdl_busdecoder.cpuif.apb4.apb4_cpuif import APB4CpuifFlat
+
+try:  # pragma: no cover - optional dependency shim
+    from cocotb.runner import get_runner
+except ImportError:  # pragma: no cover
+    from cocotb_tools.runner import get_runner
+
+from tests.cocotb_lib import RDL_CASES
+from tests.cocotb_lib.utils import colorize_cocotb_log, get_verilog_sources, prepare_cpuif_case
+
+
+@pytest.mark.simulation
+@pytest.mark.verilator
+@pytest.mark.parametrize(("rdl_file", "top_name"), RDL_CASES, ids=[case[1] for case in RDL_CASES])
+def test_apb4_stress(tmp_path: Path, rdl_file: str, top_name: str) -> None:
+    """Generate each APB4 design variant and run the randomized stress sequence."""
+    repo_root = Path(__file__).resolve().parents[4]
+    rdl_path = repo_root / "tests" / "cocotb_lib" / "rdl" / rdl_file
+    build_root = tmp_path / top_name
+
+    module_path, package_path, config = prepare_cpuif_case(
+        str(rdl_path),
+        top_name,
+        build_root,
+        cpuif_cls=APB4CpuifFlat,
+        control_signal="PSEL",
+        max_samples_per_master=0,
+    )
+
+    sources = get_verilog_sources(
+        module_path,
+        package_path,
+        [repo_root / "hdl-src" / "apb4_intf.sv"],
+    )
+
+    runner = get_runner("verilator")
+    sim_build = build_root / "sim_build"
+
+    build_log_file = build_root / "build.log"
+    sim_log_file = build_root / "simulation.log"
+
+    try:
+        runner.build(
+            sources=sources,
+            hdl_toplevel=module_path.stem,
+            build_dir=sim_build,
+            log_file=str(build_log_file),
+        )
+    except SystemExit as e:
+        if build_log_file.exists():
+            logging.error(f"""
+=== Build Log ===
+{colorize_cocotb_log(build_log_file.read_text())}
+=== End Build Log ===
+""")
+        if e.code != 0:
+            raise
+
+    try:
+        runner.test(
+            hdl_toplevel=module_path.stem,
+            test_module="tests.cocotb.apb4.smoke.test_stress",
+            build_dir=sim_build,
+            log_file=str(sim_log_file),
+            extra_env={
+                "RDL_TEST_CONFIG": json.dumps(config),
+                "RDL_TEST_SEED": "0xC0C07B",
+            },
+        )
+    except SystemExit as e:
+        if sim_log_file.exists():
+            logging.error(f"""
+=== Simulation Log ===
+{colorize_cocotb_log(sim_log_file.read_text())}
+=== End Simulation Log ===
+""")
+        if e.code != 0:
+            raise

--- a/tests/cocotb/apb4/smoke/test_stress.py
+++ b/tests/cocotb/apb4/smoke/test_stress.py
@@ -1,0 +1,143 @@
+"""APB4 stress tests: long randomized transaction streams with write/read-back checks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import cocotb
+
+from tests.cocotb.apb4.smoke.test_register_access import (
+    _Apb4SlaveShim,
+    _build_master_table,
+    _idle_masters,
+    _idle_slave,
+    _write_pattern,
+)
+from tests.cocotb_lib.protocol_utils import (
+    advance,
+    load_config,
+    make_rng,
+    set_value,
+    shuffle_transactions,
+    start_clock,
+)
+
+
+async def _apb4_write(
+    slave: _Apb4SlaveShim,
+    entry: dict[str, Any],
+    index: tuple[int, ...],
+    address: int,
+    data: int,
+    strobe: int,
+    ready_delay: int,
+) -> None:
+    set_value(entry["inputs"]["PSLVERR"], index, 0)
+    set_value(entry["inputs"]["PREADY"], index, 0)
+
+    slave.PADDR.value = address
+    slave.PWDATA.value = data
+    slave.PSTRB.value = strobe
+    slave.PWRITE.value = 1
+    slave.PSEL.value = 1
+    slave.PENABLE.value = 0
+    await advance(slave.PCLK)
+
+    slave.PENABLE.value = 1
+    for _ in range(ready_delay):
+        await advance(slave.PCLK)
+
+    set_value(entry["inputs"]["PREADY"], index, 1)
+    await advance(slave.PCLK)
+
+    slave.PSEL.value = 0
+    slave.PENABLE.value = 0
+    slave.PWRITE.value = 0
+    set_value(entry["inputs"]["PREADY"], index, 0)
+    await advance(slave.PCLK)
+
+
+async def _apb4_read(
+    slave: _Apb4SlaveShim,
+    entry: dict[str, Any],
+    index: tuple[int, ...],
+    address: int,
+    expected: int,
+    ready_delay: int,
+) -> None:
+    set_value(entry["inputs"]["PRDATA"], index, expected)
+    set_value(entry["inputs"]["PSLVERR"], index, 0)
+    set_value(entry["inputs"]["PREADY"], index, 0)
+
+    slave.PADDR.value = address
+    slave.PWRITE.value = 0
+    slave.PSEL.value = 1
+    slave.PENABLE.value = 0
+    await advance(slave.PCLK)
+
+    slave.PENABLE.value = 1
+    for _ in range(ready_delay):
+        await advance(slave.PCLK)
+
+    set_value(entry["inputs"]["PREADY"], index, 1)
+    await advance(slave.PCLK)
+    assert int(slave.PRDATA.value) == expected, (
+        f"Slave PRDATA mismatch at 0x{address:x}: "
+        f"expected 0x{expected:x}, got 0x{int(slave.PRDATA.value):x}"
+    )
+    assert int(slave.PSLVERR.value) == 0, "Stress read should not raise PSLVERR"
+
+    slave.PSEL.value = 0
+    slave.PENABLE.value = 0
+    set_value(entry["inputs"]["PREADY"], index, 0)
+    set_value(entry["inputs"]["PRDATA"], index, 0)
+    await advance(slave.PCLK)
+
+
+@cocotb.test()
+async def test_apb4_random_traffic(dut) -> None:
+    """Drive every sampled register with write/read-back in a shuffled, jittered sequence."""
+    config = load_config()
+    if not config["transactions"]:
+        dut._log.warning("No transactions available; skipping stress run")
+        return
+
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _Apb4SlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    await start_clock(slave.PCLK)
+    if slave.PRESETn is not None:
+        slave.PRESETn.value = 1
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await advance(slave.PCLK)
+
+    rng = make_rng()
+    addr_mask = (1 << config["address_width"]) - 1
+    strobe_mask = (1 << config["byte_width"]) - 1
+    shadow: dict[tuple[str, tuple[int, ...], int], int] = {}
+
+    write_order = shuffle_transactions(config["transactions"], rng)
+    for txn in write_order:
+        entry = masters[txn["master"]]
+        index = tuple(txn["index"])
+        address = txn["address"] & addr_mask
+        data = _write_pattern(address, config["data_width"])
+        # Rotate through a few strobe patterns so stress exercises more than full-word writes.
+        strobe_choices = [strobe_mask, strobe_mask, strobe_mask & 0x5, strobe_mask & 0xA]
+        strobe = rng.choice([s for s in strobe_choices if s]) or strobe_mask
+        await _apb4_write(slave, entry, index, address, data, strobe, rng.randint(0, 2))
+        shadow[(txn["master"], index, address)] = data
+
+    read_order = shuffle_transactions(config["transactions"], rng)
+    for txn in read_order:
+        entry = masters[txn["master"]]
+        index = tuple(txn["index"])
+        address = txn["address"] & addr_mask
+        expected = shadow[(txn["master"], index, address)]
+        await _apb4_read(slave, entry, index, address, expected, rng.randint(0, 2))
+
+    dut._log.info(
+        f"APB4 stress: completed {len(write_order)} writes + {len(read_order)} reads"
+    )

--- a/tests/cocotb/axi4lite/smoke/test_register_access.py
+++ b/tests/cocotb/axi4lite/smoke/test_register_access.py
@@ -13,6 +13,7 @@ from tests.cocotb_lib.protocol_utils import (
     find_invalid_address,
     get_int,
     load_config,
+    pick_distinct_pairs,
     set_value,
 )
 
@@ -109,6 +110,33 @@ def _write_pattern(address: int, width: int) -> int:
 def _read_pattern(address: int, width: int) -> int:
     mask = (1 << width) - 1
     return ((address ^ 0x2468_ACED) + width) & mask
+
+
+def _idle_slave(slave) -> None:
+    slave.AWVALID.value = 0
+    slave.AWADDR.value = 0
+    slave.AWPROT.value = 0
+    slave.WVALID.value = 0
+    slave.WDATA.value = 0
+    slave.WSTRB.value = 0
+    slave.BREADY.value = 0
+    slave.ARVALID.value = 0
+    slave.ARADDR.value = 0
+    slave.ARPROT.value = 0
+    slave.RREADY.value = 0
+
+
+def _idle_masters(masters) -> None:
+    for master_name, idx in all_index_pairs(masters):
+        entry = masters[master_name]
+        set_value(entry["inputs"]["AWREADY"], idx, 0)
+        set_value(entry["inputs"]["WREADY"], idx, 0)
+        set_value(entry["inputs"]["BVALID"], idx, 0)
+        set_value(entry["inputs"]["BRESP"], idx, 0)
+        set_value(entry["inputs"]["ARREADY"], idx, 0)
+        set_value(entry["inputs"]["RVALID"], idx, 0)
+        set_value(entry["inputs"]["RDATA"], idx, 0)
+        set_value(entry["inputs"]["RRESP"], idx, 0)
 
 
 @cocotb.test()
@@ -382,3 +410,383 @@ async def test_axi4lite_invalid_address_response(dut) -> None:
 
     assert int(slave.BVALID.value) == 1, "Invalid write should return BVALID"
     assert int(slave.BRESP.value) == 2, "Invalid write should return SLVERR"
+
+
+@cocotb.test()
+async def test_axi4lite_reset_quiescent(dut) -> None:
+    """When the slave is idle, no master should see any valid asserted."""
+    config = load_config()
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _AxilSlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await Timer(1, unit="ns")
+
+    for master_name, idx in all_index_pairs(masters):
+        entry = masters[master_name]
+        assert get_int(entry["outputs"]["AWVALID"], idx) == 0, (
+            f"{master_name}{idx} AWVALID must be idle"
+        )
+        assert get_int(entry["outputs"]["WVALID"], idx) == 0, (
+            f"{master_name}{idx} WVALID must be idle"
+        )
+        assert get_int(entry["outputs"]["ARVALID"], idx) == 0, (
+            f"{master_name}{idx} ARVALID must be idle"
+        )
+    assert int(slave.BVALID.value) == 0, "BVALID must be low while idle"
+    assert int(slave.RVALID.value) == 0, "RVALID must be low while idle"
+    assert int(slave.AWREADY.value) == 0, "AWREADY must be low while idle"
+    assert int(slave.WREADY.value) == 0, "WREADY must be low while idle"
+    assert int(slave.ARREADY.value) == 0, "ARREADY must be low while idle"
+
+
+@cocotb.test()
+async def test_axi4lite_aw_then_w(dut) -> None:
+    """AW arriving before W must trigger SLVERR, then W arriving completes the write cleanly."""
+    config = load_config()
+    if not config["transactions"]:
+        dut._log.warning("No transactions available; skipping AW→W ordering test")
+        return
+
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _AxilSlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await Timer(1, unit="ns")
+
+    txn = config["transactions"][0]
+    entry = masters[txn["master"]]
+    index = tuple(txn["index"])
+    address = txn["address"] & ((1 << config["address_width"]) - 1)
+    write_data = _write_pattern(address, config["data_width"])
+    strobe_mask = (1 << config["byte_width"]) - 1
+    master_address = (address - entry["inst_address"]) % entry["inst_size"]
+
+    # Phase 1: AW only, W deasserted. Decoder must raise SLVERR via axi_wr_invalid.
+    slave.AWADDR.value = address
+    slave.AWPROT.value = 0
+    slave.AWVALID.value = 1
+    slave.WVALID.value = 0
+    slave.BREADY.value = 1
+    await Timer(1, unit="ns")
+
+    assert int(slave.BVALID.value) == 1, "AW alone must still assert BVALID via invalid-handshake"
+    assert int(slave.BRESP.value) == 2, "AW alone must raise BRESP=SLVERR"
+    assert int(slave.AWREADY.value) == 0, "AWREADY requires both AW & W to be high"
+    for master_name, idx in all_index_pairs(masters):
+        other_entry = masters[master_name]
+        assert get_int(other_entry["outputs"]["AWVALID"], idx) == 0, (
+            f"{master_name}{idx} must not see AWVALID while W is missing"
+        )
+        assert get_int(other_entry["outputs"]["WVALID"], idx) == 0, (
+            f"{master_name}{idx} must not see WVALID while W is missing"
+        )
+
+    # Phase 2: bring W up alongside AW. Target master should now receive the request.
+    set_value(entry["inputs"]["BVALID"], index, 1)
+    set_value(entry["inputs"]["BRESP"], index, 0)
+    slave.WDATA.value = write_data
+    slave.WSTRB.value = strobe_mask
+    slave.WVALID.value = 1
+    await Timer(1, unit="ns")
+
+    assert get_int(entry["outputs"]["AWVALID"], index) == 1, "Target must see AWVALID when both channels valid"
+    assert get_int(entry["outputs"]["WVALID"], index) == 1, "Target must see WVALID when both channels valid"
+    assert get_int(entry["outputs"]["AWADDR"], index) == master_address
+    assert get_int(entry["outputs"]["WDATA"], index) == write_data
+    assert get_int(entry["outputs"]["WSTRB"], index) == strobe_mask
+    assert int(slave.AWREADY.value) == 1, "AWREADY asserts once both AW & W are valid"
+    assert int(slave.WREADY.value) == 1, "WREADY asserts once both AW & W are valid"
+    assert int(slave.BVALID.value) == 1, "BVALID should follow the master ack"
+    assert int(slave.BRESP.value) == 0, "BRESP should be OKAY for a clean master ack"
+
+
+@cocotb.test()
+async def test_axi4lite_w_then_aw(dut) -> None:
+    """W arriving before AW must not drive any master until AW joins; SLVERR is never observed."""
+    config = load_config()
+    if not config["transactions"]:
+        dut._log.warning("No transactions available; skipping W→AW ordering test")
+        return
+
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _AxilSlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await Timer(1, unit="ns")
+
+    txn = config["transactions"][0]
+    entry = masters[txn["master"]]
+    index = tuple(txn["index"])
+    address = txn["address"] & ((1 << config["address_width"]) - 1)
+    write_data = _write_pattern(address, config["data_width"])
+    strobe_mask = (1 << config["byte_width"]) - 1
+
+    # Phase 1: W only. No cpuif_req for writes → no master should engage, and BVALID must be low
+    # because axi_wr_invalid requires AW XOR W (only one high), so W alone → BVALID=1 SLVERR.
+    slave.WDATA.value = write_data
+    slave.WSTRB.value = strobe_mask
+    slave.WVALID.value = 1
+    slave.BREADY.value = 1
+    await Timer(1, unit="ns")
+
+    assert int(slave.WREADY.value) == 0, "WREADY requires both AW & W to be high"
+    for master_name, idx in all_index_pairs(masters):
+        other_entry = masters[master_name]
+        assert get_int(other_entry["outputs"]["WVALID"], idx) == 0, (
+            f"{master_name}{idx} must not see WVALID without AW"
+        )
+
+    # Phase 2: add AW. Both master channels engage and transfer completes.
+    set_value(entry["inputs"]["BVALID"], index, 1)
+    set_value(entry["inputs"]["BRESP"], index, 0)
+    slave.AWADDR.value = address
+    slave.AWPROT.value = 0
+    slave.AWVALID.value = 1
+    await Timer(1, unit="ns")
+
+    assert get_int(entry["outputs"]["AWVALID"], index) == 1
+    assert get_int(entry["outputs"]["WVALID"], index) == 1
+    assert int(slave.AWREADY.value) == 1
+    assert int(slave.WREADY.value) == 1
+    assert int(slave.BRESP.value) == 0, "BRESP should be OKAY once both channels align"
+
+
+@cocotb.test()
+async def test_axi4lite_read_wait_states(dut) -> None:
+    """Read-channel master-side signals stay stable across multi-cycle RVALID delay."""
+    config = load_config()
+    if not config["transactions"]:
+        dut._log.warning("No transactions available; skipping read wait-state test")
+        return
+
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _AxilSlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await Timer(1, unit="ns")
+
+    txn = config["transactions"][0]
+    entry = masters[txn["master"]]
+    index = tuple(txn["index"])
+    address = txn["address"] & ((1 << config["address_width"]) - 1)
+    master_address = (address - entry["inst_address"]) % entry["inst_size"]
+
+    slave.ARADDR.value = address
+    slave.ARPROT.value = 0
+    slave.ARVALID.value = 1
+    slave.RREADY.value = 1
+
+    wait_cycles = 3
+    for wait in range(wait_cycles):
+        await Timer(1, unit="ns")
+        assert get_int(entry["outputs"]["ARVALID"], index) == 1, (
+            f"ARVALID must stay high during wait cycle {wait}"
+        )
+        assert get_int(entry["outputs"]["ARADDR"], index) == master_address, (
+            f"ARADDR must remain stable during wait cycle {wait}"
+        )
+        assert int(slave.RVALID.value) == 0, (
+            f"RVALID must stay low while master stalls at wait {wait}"
+        )
+
+    read_data = _read_pattern(address, config["data_width"])
+    set_value(entry["inputs"]["RVALID"], index, 1)
+    set_value(entry["inputs"]["RDATA"], index, read_data)
+    set_value(entry["inputs"]["RRESP"], index, 0)
+    await Timer(1, unit="ns")
+
+    assert int(slave.RVALID.value) == 1, "RVALID must propagate once master releases it"
+    assert int(slave.RDATA.value) == read_data, "RDATA must match the master's response"
+    assert int(slave.RRESP.value) == 0, "RRESP should be OKAY"
+
+
+@cocotb.test()
+async def test_axi4lite_slave_error_propagation(dut) -> None:
+    """Master-sourced BRESP/RRESP SLVERR responses must surface on the slave bus."""
+    config = load_config()
+    if not config["transactions"]:
+        dut._log.warning("No transactions available; skipping slave-error test")
+        return
+
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _AxilSlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await Timer(1, unit="ns")
+
+    txn = config["transactions"][0]
+    entry = masters[txn["master"]]
+    index = tuple(txn["index"])
+    address = txn["address"] & ((1 << config["address_width"]) - 1)
+    write_data = _write_pattern(address, config["data_width"])
+    read_data = _read_pattern(address, config["data_width"])
+    strobe_mask = (1 << config["byte_width"]) - 1
+
+    # Write with master-sourced BRESP=SLVERR
+    set_value(entry["inputs"]["BVALID"], index, 1)
+    set_value(entry["inputs"]["BRESP"], index, 2)
+
+    slave.AWADDR.value = address
+    slave.AWPROT.value = 0
+    slave.AWVALID.value = 1
+    slave.WDATA.value = write_data
+    slave.WSTRB.value = strobe_mask
+    slave.WVALID.value = 1
+    slave.BREADY.value = 1
+    await Timer(1, unit="ns")
+
+    assert int(slave.BVALID.value) == 1, "BVALID must reflect master BVALID"
+    assert int(slave.BRESP.value) == 2, "BRESP must propagate SLVERR from the master"
+
+    # Return to idle before exercising read
+    slave.AWVALID.value = 0
+    slave.WVALID.value = 0
+    slave.BREADY.value = 0
+    set_value(entry["inputs"]["BVALID"], index, 0)
+    set_value(entry["inputs"]["BRESP"], index, 0)
+    await Timer(1, unit="ns")
+
+    # Read with master-sourced RRESP=SLVERR
+    set_value(entry["inputs"]["RVALID"], index, 1)
+    set_value(entry["inputs"]["RDATA"], index, read_data)
+    set_value(entry["inputs"]["RRESP"], index, 2)
+
+    slave.ARADDR.value = address
+    slave.ARPROT.value = 0
+    slave.ARVALID.value = 1
+    slave.RREADY.value = 1
+    await Timer(1, unit="ns")
+
+    assert int(slave.RVALID.value) == 1, "RVALID must reflect master RVALID"
+    assert int(slave.RRESP.value) == 2, "RRESP must propagate SLVERR from the master"
+    assert int(slave.RDATA.value) == read_data
+
+
+@cocotb.test()
+async def test_axi4lite_byte_strobes(dut) -> None:
+    """Exercise a spread of WSTRB values and verify the target master sees them intact."""
+    config = load_config()
+    if not config["transactions"]:
+        dut._log.warning("No transactions available; skipping WSTRB sweep")
+        return
+
+    byte_width = config["byte_width"]
+    full_mask = (1 << byte_width) - 1
+
+    strobe_set: list[int] = []
+    for base in (0x1, 0x2, 0x4, 0x8, 0xF, 0x5, 0xA):
+        masked = base & full_mask
+        if masked and masked not in strobe_set:
+            strobe_set.append(masked)
+    if full_mask not in strobe_set:
+        strobe_set.append(full_mask)
+
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _AxilSlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await Timer(1, unit="ns")
+
+    txn = config["transactions"][0]
+    entry = masters[txn["master"]]
+    index = tuple(txn["index"])
+    address = txn["address"] & ((1 << config["address_width"]) - 1)
+    write_data = _write_pattern(address, config["data_width"])
+    master_address = (address - entry["inst_address"]) % entry["inst_size"]
+
+    for strobe in strobe_set:
+        set_value(entry["inputs"]["BVALID"], index, 1)
+        set_value(entry["inputs"]["BRESP"], index, 0)
+
+        slave.AWADDR.value = address
+        slave.AWPROT.value = 0
+        slave.AWVALID.value = 1
+        slave.WDATA.value = write_data
+        slave.WSTRB.value = strobe
+        slave.WVALID.value = 1
+        slave.BREADY.value = 1
+        await Timer(1, unit="ns")
+
+        assert get_int(entry["outputs"]["AWADDR"], index) == master_address
+        assert get_int(entry["outputs"]["WDATA"], index) == write_data
+        assert get_int(entry["outputs"]["WSTRB"], index) == strobe, (
+            f"WSTRB 0x{strobe:x} must reach target master"
+        )
+        assert int(slave.BRESP.value) == 0, f"Strobe 0x{strobe:x} should yield OKAY"
+
+        slave.AWVALID.value = 0
+        slave.WVALID.value = 0
+        slave.BREADY.value = 0
+        set_value(entry["inputs"]["BVALID"], index, 0)
+        await Timer(1, unit="ns")
+
+
+@cocotb.test()
+async def test_axi4lite_back_to_back(dut) -> None:
+    """Two successive writes to distinct masters must each be routed correctly."""
+    config = load_config()
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _AxilSlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    pair = pick_distinct_pairs(config["transactions"], count=2)
+    if len(pair) < 2:
+        dut._log.warning("Need at least two distinct master/index transactions; skipping")
+        return
+
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await Timer(1, unit="ns")
+
+    addr_mask = (1 << config["address_width"]) - 1
+    strobe_mask = (1 << config["byte_width"]) - 1
+
+    for txn in pair:
+        entry = masters[txn["master"]]
+        index = tuple(txn["index"])
+        address = txn["address"] & addr_mask
+        write_data = _write_pattern(address, config["data_width"])
+        master_address = (address - entry["inst_address"]) % entry["inst_size"]
+
+        set_value(entry["inputs"]["BVALID"], index, 1)
+        set_value(entry["inputs"]["BRESP"], index, 0)
+
+        slave.AWADDR.value = address
+        slave.AWPROT.value = 0
+        slave.AWVALID.value = 1
+        slave.WDATA.value = write_data
+        slave.WSTRB.value = strobe_mask
+        slave.WVALID.value = 1
+        slave.BREADY.value = 1
+        await Timer(1, unit="ns")
+
+        assert get_int(entry["outputs"]["AWVALID"], index) == 1
+        assert get_int(entry["outputs"]["AWADDR"], index) == master_address
+        assert get_int(entry["outputs"]["WVALID"], index) == 1
+
+        for other_name, other_idx in all_index_pairs(masters):
+            if other_name == txn["master"] and other_idx == index:
+                continue
+            other_entry = masters[other_name]
+            assert get_int(other_entry["outputs"]["AWVALID"], other_idx) == 0, (
+                f"{other_name}{other_idx} must stay idle during {txn['label']}"
+            )
+
+        slave.AWVALID.value = 0
+        slave.WVALID.value = 0
+        slave.BREADY.value = 0
+        set_value(entry["inputs"]["BVALID"], index, 0)
+        await Timer(1, unit="ns")

--- a/tests/cocotb/axi4lite/smoke/test_runner_stress.py
+++ b/tests/cocotb/axi4lite/smoke/test_runner_stress.py
@@ -1,0 +1,87 @@
+"""Pytest wrapper launching the AXI4-Lite cocotb stress tests (exhaustive coverage)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+from peakrdl_busdecoder.cpuif.axi4lite.axi4_lite_cpuif import AXI4LiteCpuifFlat
+
+try:  # pragma: no cover - optional dependency shim
+    from cocotb.runner import get_runner
+except ImportError:  # pragma: no cover
+    from cocotb_tools.runner import get_runner
+
+from tests.cocotb_lib import RDL_CASES
+from tests.cocotb_lib.utils import colorize_cocotb_log, get_verilog_sources, prepare_cpuif_case
+
+
+@pytest.mark.simulation
+@pytest.mark.verilator
+@pytest.mark.parametrize(("rdl_file", "top_name"), RDL_CASES, ids=[case[1] for case in RDL_CASES])
+def test_axi4lite_stress(tmp_path: Path, rdl_file: str, top_name: str) -> None:
+    """Generate each AXI4-Lite design variant and run the randomized stress sequence."""
+    repo_root = Path(__file__).resolve().parents[4]
+    rdl_path = repo_root / "tests" / "cocotb_lib" / "rdl" / rdl_file
+    build_root = tmp_path / top_name
+
+    module_path, package_path, config = prepare_cpuif_case(
+        str(rdl_path),
+        top_name,
+        build_root,
+        cpuif_cls=AXI4LiteCpuifFlat,
+        control_signal="AWVALID",
+        max_samples_per_master=0,
+    )
+
+    sources = get_verilog_sources(
+        module_path,
+        package_path,
+        [repo_root / "hdl-src" / "axi4lite_intf.sv"],
+    )
+
+    runner = get_runner("verilator")
+    sim_build = build_root / "sim_build"
+
+    build_log_file = build_root / "build.log"
+    sim_log_file = build_root / "simulation.log"
+
+    try:
+        runner.build(
+            sources=sources,
+            hdl_toplevel=module_path.stem,
+            build_dir=sim_build,
+            log_file=str(build_log_file),
+        )
+    except SystemExit as e:
+        if build_log_file.exists():
+            logging.error(f"""
+=== Build Log ===
+{colorize_cocotb_log(build_log_file.read_text())}
+=== End Build Log ===
+""")
+        if e.code != 0:
+            raise
+
+    try:
+        runner.test(
+            hdl_toplevel=module_path.stem,
+            test_module="tests.cocotb.axi4lite.smoke.test_stress",
+            build_dir=sim_build,
+            log_file=str(sim_log_file),
+            extra_env={
+                "RDL_TEST_CONFIG": json.dumps(config),
+                "RDL_TEST_SEED": "0xC0C07B",
+            },
+        )
+    except SystemExit as e:
+        if sim_log_file.exists():
+            logging.error(f"""
+=== Simulation Log ===
+{colorize_cocotb_log(sim_log_file.read_text())}
+=== End Simulation Log ===
+""")
+        if e.code != 0:
+            raise

--- a/tests/cocotb/axi4lite/smoke/test_stress.py
+++ b/tests/cocotb/axi4lite/smoke/test_stress.py
@@ -1,0 +1,136 @@
+"""AXI4-Lite stress tests: long randomized transaction streams with write/read-back checks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import cocotb
+from cocotb.triggers import Timer
+
+from tests.cocotb.axi4lite.smoke.test_register_access import (
+    _AxilSlaveShim,
+    _build_master_table,
+    _idle_masters,
+    _idle_slave,
+    _write_pattern,
+)
+from tests.cocotb_lib.protocol_utils import (
+    load_config,
+    make_rng,
+    set_value,
+    shuffle_transactions,
+)
+
+
+async def _axil_write(
+    slave: _AxilSlaveShim,
+    entry: dict[str, Any],
+    index: tuple[int, ...],
+    address: int,
+    data: int,
+    strobe: int,
+) -> None:
+    set_value(entry["inputs"]["BRESP"], index, 0)
+    set_value(entry["inputs"]["BVALID"], index, 1)
+
+    slave.AWADDR.value = address
+    slave.AWPROT.value = 0
+    slave.AWVALID.value = 1
+    slave.WDATA.value = data
+    slave.WSTRB.value = strobe
+    slave.WVALID.value = 1
+    slave.BREADY.value = 1
+    await Timer(1, unit="ns")
+
+    assert int(slave.AWREADY.value) == 1, "AWREADY should assert once both AW & W are valid"
+    assert int(slave.WREADY.value) == 1, "WREADY should assert once both AW & W are valid"
+    assert int(slave.BVALID.value) == 1, "BVALID should mirror master BVALID"
+    assert int(slave.BRESP.value) == 0, f"Stress write 0x{address:x} expected OKAY BRESP"
+
+    slave.AWVALID.value = 0
+    slave.WVALID.value = 0
+    slave.BREADY.value = 0
+    set_value(entry["inputs"]["BVALID"], index, 0)
+    await Timer(1, unit="ns")
+
+
+async def _axil_read(
+    slave: _AxilSlaveShim,
+    entry: dict[str, Any],
+    index: tuple[int, ...],
+    address: int,
+    expected: int,
+    rvalid_delay: int,
+) -> None:
+    set_value(entry["inputs"]["RVALID"], index, 0)
+    set_value(entry["inputs"]["RDATA"], index, expected)
+    set_value(entry["inputs"]["RRESP"], index, 0)
+
+    slave.ARADDR.value = address
+    slave.ARPROT.value = 0
+    slave.ARVALID.value = 1
+    slave.RREADY.value = 1
+
+    for _ in range(rvalid_delay):
+        await Timer(1, unit="ns")
+
+    set_value(entry["inputs"]["RVALID"], index, 1)
+    await Timer(1, unit="ns")
+
+    assert int(slave.RVALID.value) == 1, f"RVALID must propagate at 0x{address:x}"
+    assert int(slave.RDATA.value) == expected, (
+        f"Stress read mismatch at 0x{address:x}: "
+        f"expected 0x{expected:x}, got 0x{int(slave.RDATA.value):x}"
+    )
+    assert int(slave.RRESP.value) == 0, "Stress read should yield OKAY"
+
+    slave.ARVALID.value = 0
+    slave.RREADY.value = 0
+    set_value(entry["inputs"]["RVALID"], index, 0)
+    set_value(entry["inputs"]["RDATA"], index, 0)
+    await Timer(1, unit="ns")
+
+
+@cocotb.test()
+async def test_axi4lite_random_traffic(dut) -> None:
+    """Drive every sampled register with write/read-back in a shuffled, jittered sequence."""
+    config = load_config()
+    if not config["transactions"]:
+        dut._log.warning("No transactions available; skipping stress run")
+        return
+
+    is_intf = config.get("cpuif_style") == "interface"
+    slave = _AxilSlaveShim(dut, is_interface=is_intf)
+    masters = _build_master_table(dut, config["masters"], is_interface=is_intf)
+
+    _idle_slave(slave)
+    _idle_masters(masters)
+    await Timer(1, unit="ns")
+
+    rng = make_rng()
+    addr_mask = (1 << config["address_width"]) - 1
+    strobe_mask = (1 << config["byte_width"]) - 1
+    shadow: dict[tuple[str, tuple[int, ...], int], int] = {}
+
+    write_order = shuffle_transactions(config["transactions"], rng)
+    for txn in write_order:
+        entry = masters[txn["master"]]
+        index = tuple(txn["index"])
+        address = txn["address"] & addr_mask
+        data = _write_pattern(address, config["data_width"])
+        strobe_choices = [strobe_mask, strobe_mask, strobe_mask & 0x5, strobe_mask & 0xA]
+        strobe = rng.choice([s for s in strobe_choices if s]) or strobe_mask
+        await _axil_write(slave, entry, index, address, data, strobe)
+        shadow[(txn["master"], index, address)] = data
+
+    read_order = shuffle_transactions(config["transactions"], rng)
+    for txn in read_order:
+        entry = masters[txn["master"]]
+        index = tuple(txn["index"])
+        address = txn["address"] & addr_mask
+        expected = shadow[(txn["master"], index, address)]
+        await _axil_read(slave, entry, index, address, expected, rng.randint(0, 2))
+
+    dut._log.info(
+        f"AXI4-Lite stress: completed {len(write_order)} writes + {len(read_order)} reads"
+    )

--- a/tests/cocotb_lib/protocol_utils.py
+++ b/tests/cocotb_lib/protocol_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import random
 from collections.abc import Iterable
 from typing import Any
 
@@ -99,3 +100,50 @@ async def apb_access(slave) -> None:
     """APB access phase helper."""
     slave.PENABLE.value = 1
     await Timer(1, unit="ns")
+
+
+async def advance(clk_handle) -> None:
+    """Advance one simulation step: a rising edge if clocked, otherwise a 1ns tick."""
+    if clk_handle is not None:
+        await RisingEdge(clk_handle)
+    else:
+        await Timer(1, unit="ns")
+
+
+def make_rng(env_var: str = "RDL_TEST_SEED", default: int = 0xC0C07B) -> random.Random:
+    """Deterministic RNG seeded via environment for reproducible stress runs."""
+    seed_raw = os.environ.get(env_var)
+    if seed_raw is None:
+        seed = default
+    else:
+        seed = int(seed_raw, 0)
+    return random.Random(seed)
+
+
+def shuffle_transactions(transactions: list[dict[str, Any]], rng: random.Random) -> list[dict[str, Any]]:
+    """Return a freshly shuffled copy of ``transactions`` using ``rng``."""
+    shuffled = list(transactions)
+    rng.shuffle(shuffled)
+    return shuffled
+
+
+def pick_distinct_pairs(
+    transactions: list[dict[str, Any]], count: int = 2
+) -> list[dict[str, Any]]:
+    """Return up to ``count`` transactions that target distinct (master, index) pairs.
+
+    Stress / back-to-back tests need traffic that actually switches masters, so
+    we scan the sampled transaction list and keep the first transaction for each
+    unique (master, index) tuple.
+    """
+    seen: set[tuple[str, tuple[int, ...]]] = set()
+    picked: list[dict[str, Any]] = []
+    for txn in transactions:
+        key = (txn["master"], tuple(txn["index"]))
+        if key in seen:
+            continue
+        seen.add(key)
+        picked.append(txn)
+        if len(picked) >= count:
+            break
+    return picked

--- a/tests/cocotb_lib/utils.py
+++ b/tests/cocotb_lib/utils.py
@@ -332,7 +332,8 @@ def _build_case_config(
 
 
 def _sample_addresses(addresses: list[int], max_samples: int) -> list[int]:
-    if len(addresses) <= max_samples:
+    # ``max_samples <= 0`` requests every address (used by stress runners).
+    if max_samples <= 0 or len(addresses) <= max_samples:
         return addresses
 
     samples: list[int] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-collect_ignore_glob = ["cocotb/*/smoke/test_register_access.py", "cocotb/*/smoke/test_variable_depth.py"]
+collect_ignore_glob = [
+    "cocotb/*/smoke/test_register_access.py",
+    "cocotb/*/smoke/test_variable_depth.py",
+    "cocotb/*/smoke/test_stress.py",
+]
 
 import os
 from collections.abc import Callable

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "peakrdl-busdecoder"
-version = "0.7.0b2"
+version = "0.7.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
# Description of change

This PR adds extensive test coverage for AXI4-Lite, APB3, and APB4 bus decoder implementations, including:

## New Test Cases

**AXI4-Lite (`test_register_access.py`)**:
- `test_axi4lite_reset_quiescent`: Verifies idle state with no valid signals asserted
- `test_axi4lite_aw_then_w`: Tests AW arriving before W triggers SLVERR, then W completes cleanly
- `test_axi4lite_w_then_aw`: Tests W arriving before AW remains idle until AW joins
- `test_axi4lite_read_wait_states`: Validates read-channel stability across multi-cycle RVALID delays
- `test_axi4lite_slave_error_propagation`: Verifies master-sourced BRESP/RRESP errors surface on slave bus

**APB3/APB4 (`test_register_access.py`)**:
- `test_apb*_reset_quiescent`: Verifies PSEL remains deasserted when bus is idle
- `test_apb*_setup_access_stability`: Validates command signals remain stable across wait states
- `test_apb*_back_to_back`: Tests successive transfers to distinct masters complete cleanly
- `test_apb*_slave_error_passthrough`: Verifies PSLVERR from target master surfaces on bus

**Stress Tests** (new files):
- `test_stress.py` for each protocol: Randomized write/read-back sequences with shuffled transaction ordering and variable ready delays
- `test_runner_stress.py` for each protocol: Pytest wrappers that generate designs and run stress tests with deterministic seeding

## Helper Functions

Added utility functions to support new tests:
- `_idle_slave()` / `_idle_masters()`: Initialize bus to quiescent state
- `advance()`: Protocol-agnostic clock/timer advancement
- `make_rng()`: Deterministic RNG seeded via environment variable for reproducible stress runs
- `shuffle_transactions()`: Randomize transaction order
- `pick_distinct_pairs()`: Select transactions targeting distinct (master, index) pairs

## Key Features

- Tests cover protocol edge cases: channel ordering, wait states, error propagation, and reset behavior
- Stress tests exercise exhaustive address coverage with randomized patterns
- Deterministic seeding (`RDL_TEST_SEED` env var) enables reproducible test runs
- Tests skip gracefully when insufficient transactions are available
- Comprehensive assertions validate both master-side and slave-side signal behavior

# Checklist

- [x] I have reviewed this project's [contribution guidelines](https://github.com/arnavsacheti/PeakRDL-BusDecoder/blob/main/CONTRIBUTING.md)
- [x] This change has been tested and does not break any of the existing unit tests
- [x] New unit tests have been added that cover the new functionality

https://claude.ai/code/session_01Hir39fXm28dBaPMNWyyK8F