### PR TITLE
perf: cache per-node facts in DesignScanner to eliminate redundant walks

### DIFF
--- a/src/peakrdl_busdecoder/cpuif/fanin_gen.py
+++ b/src/peakrdl_busdecoder/cpuif/fanin_gen.py
@@ -29,10 +29,7 @@ class FaninGenerator(BusDecoderListener):
         should_generate = action == WalkerAction.SkipDescendants
 
         if not should_generate and self._ds.max_decode_depth == 0:
-            for child in node.children():
-                if isinstance(child, AddressableNode):
-                    break
-            else:
+            if not self._ds.node_meta(node).has_addressable_children:
                 should_generate = True
 
         if node.array_dimensions:

--- a/src/peakrdl_busdecoder/cpuif/fanout_gen.py
+++ b/src/peakrdl_busdecoder/cpuif/fanout_gen.py
@@ -25,10 +25,7 @@ class FanoutGenerator(BusDecoderListener):
 
         should_generate = action == WalkerAction.SkipDescendants
         if not should_generate and self._ds.max_decode_depth == 0:
-            for child in node.children():
-                if isinstance(child, AddressableNode):
-                    break
-            else:
+            if not self._ds.node_meta(node).has_addressable_children:
                 should_generate = True
 
         if node.array_dimensions:

--- a/src/peakrdl_busdecoder/decode_logic_gen.py
+++ b/src/peakrdl_busdecoder/decode_logic_gen.py
@@ -97,10 +97,7 @@ class DecodeLogicGenerator(BusDecoderListener):
 
         if not should_decode and self._ds.max_decode_depth == 0:
             # When decoding all levels, treat leaf registers as decode boundary
-            for child in node.children():
-                if isinstance(child, AddressableNode):
-                    break
-            else:
+            if not self._ds.node_meta(node).has_addressable_children:
                 should_decode = True
 
         conditions: list[str] = []

--- a/src/peakrdl_busdecoder/design_scanner.py
+++ b/src/peakrdl_busdecoder/design_scanner.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING
 from systemrdl.node import AddressableNode, AddrmapNode, Node, RegNode
 from systemrdl.walker import RDLListener, RDLWalker, WalkerAction
 
+from .node_meta import NodeMeta
+
 if TYPE_CHECKING:
     from .design_state import DesignState
 
@@ -28,10 +30,48 @@ class DesignScanner(RDLListener):
         if self.msg.had_error:
             self.msg.fatal("Unable to export due to previous errors")
 
+    def _record_meta(self, node: Node) -> None:
+        if not isinstance(node, AddressableNode):
+            return
+
+        addressable_children = [c for c in node.children() if isinstance(c, AddressableNode)]
+        has_addressable_children = bool(addressable_children)
+        has_only_external_addressable_children = has_addressable_children and all(
+            c.external for c in addressable_children
+        )
+
+        array_strides: tuple[int, ...] | None
+        if node.array_dimensions:
+            assert node.array_stride is not None, "Array stride should be defined for arrayed components"
+            # Stored innermost-first: [stride, stride*dim_last, stride*dim_last*dim_prev, ...].
+            # Listener replays as append(strides[0]) then appendleft for the rest, matching
+            # the original nested-stride bookkeeping exactly.
+            strides_list: list[int] = [node.array_stride]
+            current = node.array_stride
+            for dim in node.array_dimensions[-1:0:-1]:
+                current = current * dim
+                strides_list.append(current)
+            array_strides = tuple(strides_list)
+        else:
+            array_strides = None
+
+        rel_path = "" if node is self.top_node else node.get_rel_path(self.top_node)
+
+        self.ds._node_meta[node.get_path()] = NodeMeta(
+            has_only_external_addressable_children=has_only_external_addressable_children,
+            has_addressable_children=has_addressable_children,
+            array_strides=array_strides,
+            rel_path=rel_path,
+        )
+
     def enter_Component(self, node: Node) -> WalkerAction:
+        self._record_meta(node)
+
         if node.external and (node != self.top_node):
-            # Do not inspect external components. None of my business
-            return WalkerAction.SkipDescendants
+            # Do not inspect external components' properties (none of my business),
+            # but continue descending so per-node meta is populated for children
+            # that downstream listeners will still visit.
+            return WalkerAction.Continue
 
         # Collect any signals that are referenced by a property
         for prop_name in node.list_properties():

--- a/src/peakrdl_busdecoder/design_state.py
+++ b/src/peakrdl_busdecoder/design_state.py
@@ -7,6 +7,7 @@ from systemrdl.rdltypes.user_enum import UserEnum
 
 from .design_scanner import DesignScanner
 from .identifier_filter import kw_filter as kwf
+from .node_meta import NodeMeta
 from .rdl_params import ParameterUsage, RdlParameter, RdlParameterExtractor
 from .utils import clog2
 
@@ -53,6 +54,11 @@ class DesignState:
 
         self.has_external_addressable = False
         self.has_external_block = False
+
+        # Per-node facts cached during the scan walk so downstream listeners
+        # don't recompute the same predicates on each pass.
+        self._node_meta: dict[str, NodeMeta] = {}
+        self._addressable_children_cache: dict[tuple[int, bool], list[AddressableNode]] = {}
 
         # Scan the design to fill in above variables
         DesignScanner(self).do_scan()
@@ -113,6 +119,9 @@ class DesignState:
             self.enable_rdl_params = []
             self._enable_params_by_node_dim = {}
 
+    def node_meta(self, node: AddressableNode) -> NodeMeta:
+        return self._node_meta[node.get_path()]
+
     def get_enable_param_for_dimension(self, node: AddressableNode, dim_index: int) -> RdlParameter | None:
         """
         Look up the enable parameter for a specific array dimension of a node.
@@ -120,7 +129,8 @@ class DesignState:
         Returns the RdlParameter if this dimension is controlled by a
         root-level ADDRESS_MODIFYING parameter, or None otherwise.
         """
-        node_path = node.get_rel_path(self.top_node)
+        meta = self._node_meta.get(node.get_path())
+        node_path = meta.rel_path if meta is not None else node.get_rel_path(self.top_node)
         return self._enable_params_by_node_dim.get((node_path, dim_index))
 
     def resolve_loop_bound(self, node: AddressableNode, dim_index: int, dim: int) -> int | str:
@@ -145,6 +155,11 @@ class DesignState:
             List of addressable nodes at the decode boundary
         """
         from systemrdl.node import RegNode
+
+        cache_key = (self.max_decode_depth, unroll)
+        cached = self._addressable_children_cache.get(cache_key)
+        if cached is not None:
+            return cached
 
         def collect_nodes(node: AddressableNode, current_depth: int) -> list[AddressableNode]:
             """Recursively collect nodes at the decode boundary."""
@@ -179,4 +194,5 @@ class DesignState:
             if isinstance(child, AddressableNode):
                 nodes.extend(collect_nodes(child, 1))
 
+        self._addressable_children_cache[cache_key] = nodes
         return nodes

--- a/src/peakrdl_busdecoder/listener.py
+++ b/src/peakrdl_busdecoder/listener.py
@@ -25,24 +25,18 @@ class BusDecoderListener(RDLListener):
 
         # Check if this node only contains external addressable children
         if node != self._ds.top_node and not isinstance(node, RegNode):
-            if any(isinstance(c, AddressableNode) for c in node.children()) and all(
-                c.external for c in node.children() if isinstance(c, AddressableNode)
-            ):
+            if self._ds.node_meta(node).has_only_external_addressable_children:
                 return True
 
         return False
 
     def enter_AddressableComponent(self, node: AddressableNode) -> WalkerAction | None:
-        if node.array_dimensions:
-            assert node.array_stride is not None, "Array stride should be defined for arrayed components"
-            current_stride = node.array_stride
-            self._array_stride_stack.append(current_stride)
-
-            # Work backwards from rightmost to leftmost dimension (fastest to slowest changing)
-            # Each dimension's stride is the product of its size and the previous dimension's stride
-            for dim in node.array_dimensions[-1:0:-1]:
-                current_stride = current_stride * dim
-                self._array_stride_stack.appendleft(current_stride)
+        meta = self._ds.node_meta(node)
+        if meta.array_strides is not None:
+            strides = meta.array_strides
+            self._array_stride_stack.append(strides[0])
+            for stride in strides[1:]:
+                self._array_stride_stack.appendleft(stride)
 
         self._depth += 1
 

--- a/src/peakrdl_busdecoder/node_meta.py
+++ b/src/peakrdl_busdecoder/node_meta.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class NodeMeta:
+    has_only_external_addressable_children: bool
+    has_addressable_children: bool
+    array_strides: tuple[int, ...] | None
+    rel_path: str

--- a/src/peakrdl_busdecoder/struct_gen.py
+++ b/src/peakrdl_busdecoder/struct_gen.py
@@ -26,8 +26,7 @@ class StructGenerator(BusDecoderListener):
         skip = action == WalkerAction.SkipDescendants
 
         # Only create nested struct if we're not skipping and node has addressable children
-        has_addressable_children = any(isinstance(child, AddressableNode) for child in node.children())
-        if has_addressable_children and not skip:
+        if self._ds.node_meta(node).has_addressable_children and not skip:
             # Push new body onto stack
             body = StructBody(f"cpuif_sel_{node.inst_name}_t", True, False)
             self._stack.append(body)


### PR DESCRIPTION
## Summary

- Compute per-node predicates once during the existing `DesignScanner` walk and store them on `DesignState` keyed by `node.get_path()`. Downstream listeners read from the cache instead of re-iterating `node.children()` and recomputing strides on every pass.
- Cached facts (in new `node_meta.py`):
  - `has_addressable_children` — replaces the `for child in node.children(): break / else: should_generate = True` pattern in `FanoutGenerator`, `FaninGenerator`, `DecodeLogicGenerator`, and the `any(isinstance(c, AddressableNode) ...)` check in `StructGenerator`.
  - `has_only_external_addressable_children` — replaces the inline `any(...) and all(...)` over `node.children()` in `BusDecoderListener.should_skip_node`.
  - `array_strides` — replaces the per-walk nested-stride bookkeeping in `BusDecoderListener.enter_AddressableComponent`.
  - `rel_path` — used by `DesignState.get_enable_param_for_dimension`.
- Memoize `DesignState.get_addressable_children_at_depth` by `(max_decode_depth, unroll)`.
- The scanner now continues descending into external-addressable subtrees so meta is populated for nodes the listeners still visit; property collection is still skipped for external nodes to preserve prior behavior.

This is a pure refactor — generated SystemVerilog must be byte-identical to before.

## Test plan

- [x] `pytest tests/unit/ tests/exporter/ tests/body/ tests/utils/` — 174 passed, 1 skipped
- Exporter tests (fixture comparison against checked-in golden RTL) all pass with no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)