### PR TITLE
feat: make APB downstream signal gating opt-in via --gate-signals

### DIFF
--- a/src/peakrdl_busdecoder/__peakrdl__.py
+++ b/src/peakrdl_busdecoder/__peakrdl__.py
@@ -134,6 +134,17 @@ class Exporter(ExporterSubcommandPlugin):
             """,
         )
 
+        arg_group.add_argument(
+            "--gate-signals",
+            action="store_true",
+            default=False,
+            help="""Gate downstream broadcast signals with the per-slave select.
+            For APB this drives PENABLE/PADDR/PWDATA/PSTRB/PPROT to '0 on
+            unselected masters (APB protocol-correct). When omitted, broadcast
+            signals fan out unmodified.
+            """,
+        )
+
     def do_export(self, top_node: AddrmapNode, options: argparse.Namespace) -> None:
         cpuifs = self.get_cpuifs()
 
@@ -148,4 +159,5 @@ class Exporter(ExporterSubcommandPlugin):
             cpuif_unroll=options.unroll,
             parametrize=options.parametrize,
             max_decode_depth=options.max_decode_depth,
+            gate_signals=options.gate_signals,
         )

--- a/src/peakrdl_busdecoder/cpuif/apb3/apb3_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/apb3/apb3_cpuif.py
@@ -44,6 +44,7 @@ class APB3CpuifFlat(BaseCpuif):
 
     def fanout(self, node: AddressableNode, array_stack: deque[int]) -> str:
         fanout: dict[str, str] = {}
+        gate = self.exp.ds.gate_signals
 
         addr_width = f"{self.exp.ds.module_name.upper()}_{node.inst_name.upper()}_ADDR_WIDTH"
 
@@ -52,7 +53,9 @@ class APB3CpuifFlat(BaseCpuif):
             f"|cpuif_rd_sel.{get_indexed_path(self.exp.ds.top_node, node, 'gi')}"
         )
         fanout[self.signal("PSEL", node, "gi")] = sel_expr
-        fanout[self.signal("PENABLE", node, "gi")] = f"({sel_expr}) & {self.signal('PENABLE')}"
+        fanout[self.signal("PENABLE", node, "gi")] = (
+            f"({sel_expr}) & {self.signal('PENABLE')}" if gate else self.signal("PENABLE")
+        )
         fanout[self.signal("PWRITE", node, "gi")] = (
             f"cpuif_wr_sel.{get_indexed_path(self.exp.ds.top_node, node, 'gi')}"
         )
@@ -65,8 +68,10 @@ class APB3CpuifFlat(BaseCpuif):
                 addr_comp.append(f"{self.addr_width}'(gi{i}*{SVInt(stride, self.addr_width)})")
 
             addr_value = f"{addr_width}'({' - '.join(addr_comp)})"
-        fanout[self.signal("PADDR", node, "gi")] = f"({sel_expr}) ? {addr_value} : '0"
-        fanout[self.signal("PWDATA", node, "gi")] = f"({sel_expr}) ? cpuif_wr_data : '0"
+        fanout[self.signal("PADDR", node, "gi")] = f"({sel_expr}) ? {addr_value} : '0" if gate else addr_value
+        fanout[self.signal("PWDATA", node, "gi")] = (
+            f"({sel_expr}) ? cpuif_wr_data : '0" if gate else "cpuif_wr_data"
+        )
 
         return "\n".join(f"assign {kv[0]} = {kv[1]};" for kv in fanout.items())
 

--- a/src/peakrdl_busdecoder/cpuif/apb4/apb4_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/apb4/apb4_cpuif.py
@@ -44,6 +44,7 @@ class APB4CpuifFlat(BaseCpuif):
 
     def fanout(self, node: AddressableNode, array_stack: deque[int]) -> str:
         fanout: dict[str, str] = {}
+        gate = self.exp.ds.gate_signals
 
         addr_width = f"{self.exp.ds.module_name.upper()}_{node.inst_name.upper()}_ADDR_WIDTH"
 
@@ -52,7 +53,9 @@ class APB4CpuifFlat(BaseCpuif):
             f"|cpuif_rd_sel.{get_indexed_path(self.exp.ds.top_node, node, 'gi')}"
         )
         fanout[self.signal("PSEL", node, "gi")] = sel_expr
-        fanout[self.signal("PENABLE", node, "gi")] = f"({sel_expr}) & {self.signal('PENABLE')}"
+        fanout[self.signal("PENABLE", node, "gi")] = (
+            f"({sel_expr}) & {self.signal('PENABLE')}" if gate else self.signal("PENABLE")
+        )
         fanout[self.signal("PWRITE", node, "gi")] = (
             f"cpuif_wr_sel.{get_indexed_path(self.exp.ds.top_node, node, 'gi')}"
         )
@@ -65,10 +68,16 @@ class APB4CpuifFlat(BaseCpuif):
                 addr_comp.append(f"{self.addr_width}'(gi{i}*{SVInt(stride, self.addr_width)})")
 
             addr_value = f"{addr_width}'({' - '.join(addr_comp)})"
-        fanout[self.signal("PADDR", node, "gi")] = f"({sel_expr}) ? {addr_value} : '0"
-        fanout[self.signal("PPROT", node, "gi")] = f"({sel_expr}) ? {self.signal('PPROT')} : '0"
-        fanout[self.signal("PWDATA", node, "gi")] = f"({sel_expr}) ? cpuif_wr_data : '0"
-        fanout[self.signal("PSTRB", node, "gi")] = f"({sel_expr}) ? cpuif_wr_byte_en : '0"
+        fanout[self.signal("PADDR", node, "gi")] = f"({sel_expr}) ? {addr_value} : '0" if gate else addr_value
+        fanout[self.signal("PPROT", node, "gi")] = (
+            f"({sel_expr}) ? {self.signal('PPROT')} : '0" if gate else self.signal("PPROT")
+        )
+        fanout[self.signal("PWDATA", node, "gi")] = (
+            f"({sel_expr}) ? cpuif_wr_data : '0" if gate else "cpuif_wr_data"
+        )
+        fanout[self.signal("PSTRB", node, "gi")] = (
+            f"({sel_expr}) ? cpuif_wr_byte_en : '0" if gate else "cpuif_wr_byte_en"
+        )
 
         return "\n".join(f"assign {kv[0]} = {kv[1]};" for kv in fanout.items())
 

--- a/src/peakrdl_busdecoder/design_state.py
+++ b/src/peakrdl_busdecoder/design_state.py
@@ -20,6 +20,7 @@ class DesignStateKwargs(TypedDict, total=False):
     cpuif_unroll: bool
     parametrize: bool
     max_decode_depth: int
+    gate_signals: bool
 
 
 class DesignState:
@@ -43,6 +44,7 @@ class DesignState:
         self.cpuif_unroll: bool = kwargs.pop("cpuif_unroll", False)
         self.parametrize: bool = kwargs.pop("parametrize", False)
         self.max_decode_depth: int = kwargs.pop("max_decode_depth", 1)
+        self.gate_signals: bool = kwargs.pop("gate_signals", False)
 
         # ------------------------
         # Info about the design

--- a/src/peakrdl_busdecoder/exporter.py
+++ b/src/peakrdl_busdecoder/exporter.py
@@ -29,6 +29,7 @@ class ExporterKwargs(TypedDict, total=False):
     parametrize: bool
     reuse_hwif_typedefs: bool
     max_decode_depth: int
+    gate_signals: bool
 
 
 if TYPE_CHECKING:

--- a/tests/cocotb/apb3/smoke/test_runner.py
+++ b/tests/cocotb/apb3/smoke/test_runner.py
@@ -33,6 +33,7 @@ def test_apb3_smoke(tmp_path: Path, rdl_file: str, top_name: str) -> None:
         build_root,
         cpuif_cls=APB3CpuifFlat,
         control_signal="PSEL",
+        exporter_kwargs={"gate_signals": True},
     )
 
     sources = get_verilog_sources(

--- a/tests/cocotb/apb3/smoke/test_runner_intf.py
+++ b/tests/cocotb/apb3/smoke/test_runner_intf.py
@@ -35,6 +35,7 @@ def test_apb3_intf_smoke(tmp_path: Path, rdl_file: str, top_name: str) -> None:
         build_root,
         cpuif_cls=APB3Cpuif,
         control_signal="PSEL",
+        exporter_kwargs={"gate_signals": True},
     )
 
     # Generate Verilator wrapper (Verilator can't have SV interface ports at top level)

--- a/tests/cocotb/apb4/smoke/test_runner.py
+++ b/tests/cocotb/apb4/smoke/test_runner.py
@@ -36,6 +36,7 @@ def test_apb4_smoke(tmp_path: Path, rdl_file: str, top_name: str) -> None:
         build_root,
         cpuif_cls=APB4CpuifFlat,
         control_signal="PSEL",
+        exporter_kwargs={"gate_signals": True},
     )
 
     sources = get_verilog_sources(

--- a/tests/cocotb/apb4/smoke/test_runner_intf.py
+++ b/tests/cocotb/apb4/smoke/test_runner_intf.py
@@ -35,6 +35,7 @@ def test_apb4_intf_smoke(tmp_path: Path, rdl_file: str, top_name: str) -> None:
         build_root,
         cpuif_cls=APB4Cpuif,
         control_signal="PSEL",
+        exporter_kwargs={"gate_signals": True},
     )
 
     # Generate Verilator wrapper (Verilator can't have SV interface ports at top level)

--- a/tests/unit/test_gate_signals.py
+++ b/tests/unit/test_gate_signals.py
@@ -1,0 +1,72 @@
+"""Tests for the --gate-signals / gate_signals=True opt-in feature."""
+
+from collections.abc import Callable
+from pathlib import Path
+
+from systemrdl.node import AddrmapNode
+
+from peakrdl_busdecoder import BusDecoderExporter
+from peakrdl_busdecoder.cpuif.apb3 import APB3CpuifFlat
+from peakrdl_busdecoder.cpuif.apb4 import APB4CpuifFlat
+
+
+_RDL = """
+addrmap multi_slave {
+    reg { field { sw=rw; hw=r; } data[31:0]; } a @ 0x0;
+    reg { field { sw=rw; hw=r; } data[31:0]; } b @ 0x4;
+};
+"""
+
+
+def test_apb4_default_does_not_gate(
+    compile_rdl: Callable[..., AddrmapNode], tmp_path: Path
+) -> None:
+    top = compile_rdl(_RDL, top="multi_slave")
+    BusDecoderExporter().export(top, str(tmp_path), cpuif_cls=APB4CpuifFlat)
+    sv = (tmp_path / "multi_slave.sv").read_text()
+    # PENABLE/PADDR/PWDATA/PSTRB/PPROT must fan out unmodified
+    assert "= s_apb_PENABLE;" in sv
+    assert "= cpuif_wr_data;" in sv
+    assert "= s_apb_PSTRB;" in sv
+    assert "= s_apb_PPROT;" in sv
+    # No gating expression on broadcast signals
+    assert "& s_apb_PENABLE" not in sv
+    assert "? cpuif_wr_data : '0" not in sv
+
+
+def test_apb4_gate_signals_emits_gating(
+    compile_rdl: Callable[..., AddrmapNode], tmp_path: Path
+) -> None:
+    top = compile_rdl(_RDL, top="multi_slave")
+    BusDecoderExporter().export(
+        top, str(tmp_path), cpuif_cls=APB4CpuifFlat, gate_signals=True
+    )
+    sv = (tmp_path / "multi_slave.sv").read_text()
+    assert "& s_apb_PENABLE" in sv
+    assert "? cpuif_wr_data : '0" in sv
+    assert "? s_apb_PPROT : '0" in sv
+    assert "? cpuif_wr_byte_en : '0" in sv
+
+
+def test_apb3_default_does_not_gate(
+    compile_rdl: Callable[..., AddrmapNode], tmp_path: Path
+) -> None:
+    top = compile_rdl(_RDL, top="multi_slave")
+    BusDecoderExporter().export(top, str(tmp_path), cpuif_cls=APB3CpuifFlat)
+    sv = (tmp_path / "multi_slave.sv").read_text()
+    assert "= s_apb_PENABLE;" in sv
+    assert "= cpuif_wr_data;" in sv
+    assert "& s_apb_PENABLE" not in sv
+    assert "? cpuif_wr_data : '0" not in sv
+
+
+def test_apb3_gate_signals_emits_gating(
+    compile_rdl: Callable[..., AddrmapNode], tmp_path: Path
+) -> None:
+    top = compile_rdl(_RDL, top="multi_slave")
+    BusDecoderExporter().export(
+        top, str(tmp_path), cpuif_cls=APB3CpuifFlat, gate_signals=True
+    )
+    sv = (tmp_path / "multi_slave.sv").read_text()
+    assert "& s_apb_PENABLE" in sv
+    assert "? cpuif_wr_data : '0" in sv


### PR DESCRIPTION
## Summary

Adds a new `--gate-signals` CLI flag (and `gate_signals=True` exporter kwarg) that toggles per-slave gating of APB broadcast signals (`PENABLE`, `PADDR`, `PWDATA`, `PSTRB`, `PPROT`).

- **Default off.** Broadcast signals fan out unmodified — fewer logic stages on the master→slave datapath.
- **`--gate-signals` on.** Each broadcast signal is masked by the slave's select expression: `(sel) ? signal : '0` (and `(sel) & PENABLE`).

## Rationale

The gating mux adds an extra LUT stage on the longest combinational path from CPU master input to slave input — a real timing cost on tight `PCLK` designs. The previous default forced every consumer to absorb that stage; making it opt-in keeps the timing-friendly path as the default.

Per the AMBA APB spec, well-behaved slaves only sample these signals when their `PSEL` is asserted, so toggling them while `PSEL=0` is benign. Gating is useful when:

- Lower switching activity on quiet sub-blocks is desired (power, EMI).
- Cleaner debug waveforms (unselected slaves show flat lines).
- Defending against non-conformant slaves that latch inputs without checking `PSEL`.

`PSEL` itself is always per-slave and unaffected by this flag. `PWRITE` is already driven per-slave from `cpuif_wr_sel.X` and is also unaffected.

## Test plan

- [x] `pytest tests/unit/ tests/exporter/ tests/body/ tests/utils/` — 178 passed, 1 skipped (4 new tests in `tests/unit/test_gate_signals.py` cover both modes for APB3 and APB4)
- [x] Cocotb register-access smoke runners that assert \`PENABLE == 0\` on unselected masters opt into gating (\`exporter_kwargs={\"gate_signals\": True}\`); stress runners exercise the default ungated path
- [ ] Cocotb smoke (Verilator): not run in CI here

🤖 Generated with [Claude Code](https://claude.com/claude-code)