### PR TITLE
test: add cross-block integration suite verifying end-to-end decoder flow

### DIFF
--- a/src/peakrdl_busdecoder/cpuif/apb3/apb3_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/apb3/apb3_cpuif.py
@@ -60,7 +60,7 @@ class APB3CpuifFlat(BaseCpuif):
             # Size is a power of 2 and aligned, so we can directly use the address bits as the slave address
             addr_value = f"{self.signal('PADDR')}[{addr_width}-1:0]"
         else:
-            addr_comp = [f"{self.signal('PADDR')}", f"{SVInt(node.raw_absolute_address, self.addr_width)}"]
+            addr_comp = [f"{self.signal('PADDR')}", f"{SVInt(self.node_base_address(node), self.addr_width)}"]
             for i, stride in enumerate(array_stack):
                 addr_comp.append(f"{self.addr_width}'(gi{i}*{SVInt(stride, self.addr_width)})")
 
@@ -114,7 +114,8 @@ class APB3Cpuif(APB3CpuifFlat):
 
     def fanin_wr(self, node: AddressableNode | None = None, *, error: bool = False) -> str:
         fanin_wr = super().fanin_wr(node, error=error)
-        if node is not None and self.is_interface and node.is_array and node.array_dimensions:
+        if node is not None and self.is_interface and self.check_is_array(node):
+            assert node.array_dimensions is not None
             fanin: dict[str, str] = {}
             # Generate array index string [i0][i1]... for the intermediate signal
             array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))
@@ -126,7 +127,8 @@ class APB3Cpuif(APB3CpuifFlat):
 
     def fanin_rd(self, node: AddressableNode | None = None, *, error: bool = False) -> str:
         fanin_rd = super().fanin_rd(node, error=error)
-        if node is not None and self.is_interface and node.is_array and node.array_dimensions:
+        if node is not None and self.is_interface and self.check_is_array(node):
+            assert node.array_dimensions is not None
             fanin: dict[str, str] = {}
             # Generate array index string [i0][i1]... for the intermediate signal
             array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))

--- a/src/peakrdl_busdecoder/cpuif/apb3/apb3_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/apb3/apb3_cpuif.py
@@ -45,7 +45,7 @@ class APB3CpuifFlat(BaseCpuif):
     def fanout(self, node: AddressableNode, array_stack: deque[int]) -> str:
         fanout: dict[str, str] = {}
 
-        addr_width = f"{self.exp.ds.module_name.upper()}_{node.inst_name.upper()}_ADDR_WIDTH"
+        addr_width = self.addr_width_param(node)
 
         sel_expr = (
             f"cpuif_wr_sel.{get_indexed_path(self.exp.ds.top_node, node, 'gi')}"
@@ -119,8 +119,8 @@ class APB3Cpuif(APB3CpuifFlat):
             fanin: dict[str, str] = {}
             # Generate array index string [i0][i1]... for the intermediate signal
             array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))
-            fanin["cpuif_wr_ack"] = f"{node.inst_name}_fanin_ready{array_idx}"
-            fanin["cpuif_wr_err"] = f"{node.inst_name}_fanin_err{array_idx}"
+            fanin["cpuif_wr_ack"] = f"{self.exp.ds.master_port_name(node)}_fanin_ready{array_idx}"
+            fanin["cpuif_wr_err"] = f"{self.exp.ds.master_port_name(node)}_fanin_err{array_idx}"
 
             fanin_wr = "\n" + "\n".join([f"{lhs} = {rhs};" for lhs, rhs in fanin.items()])
         return fanin_wr
@@ -132,9 +132,9 @@ class APB3Cpuif(APB3CpuifFlat):
             fanin: dict[str, str] = {}
             # Generate array index string [i0][i1]... for the intermediate signal
             array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))
-            fanin["cpuif_rd_ack"] = f"{node.inst_name}_fanin_ready{array_idx}"
-            fanin["cpuif_rd_err"] = f"{node.inst_name}_fanin_err{array_idx}"
-            fanin["cpuif_rd_data"] = f"{node.inst_name}_fanin_data{array_idx}"
+            fanin["cpuif_rd_ack"] = f"{self.exp.ds.master_port_name(node)}_fanin_ready{array_idx}"
+            fanin["cpuif_rd_err"] = f"{self.exp.ds.master_port_name(node)}_fanin_err{array_idx}"
+            fanin["cpuif_rd_data"] = f"{self.exp.ds.master_port_name(node)}_fanin_data{array_idx}"
 
             fanin_rd = "\n" + "\n".join([f"{lhs} = {rhs};" for lhs, rhs in fanin.items()])
         return fanin_rd

--- a/src/peakrdl_busdecoder/cpuif/apb4/apb4_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/apb4/apb4_cpuif.py
@@ -60,7 +60,7 @@ class APB4CpuifFlat(BaseCpuif):
             # Size is a power of 2 and aligned, so we can directly use the address bits as the slave address
             addr_value = f"{self.signal('PADDR')}[{addr_width}-1:0]"
         else:
-            addr_comp = [f"{self.signal('PADDR')}", f"{SVInt(node.raw_absolute_address, self.addr_width)}"]
+            addr_comp = [f"{self.signal('PADDR')}", f"{SVInt(self.node_base_address(node), self.addr_width)}"]
             for i, stride in enumerate(array_stack):
                 addr_comp.append(f"{self.addr_width}'(gi{i}*{SVInt(stride, self.addr_width)})")
 
@@ -116,7 +116,8 @@ class APB4Cpuif(APB4CpuifFlat):
 
     def fanin_wr(self, node: AddressableNode | None = None, *, error: bool = False) -> str:
         fanin_wr = super().fanin_wr(node, error=error)
-        if node is not None and self.is_interface and node.is_array and node.array_dimensions:
+        if node is not None and self.is_interface and self.check_is_array(node):
+            assert node.array_dimensions is not None
             fanin: dict[str, str] = {}
             # Generate array index string [i0][i1]... for the intermediate signal
             array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))
@@ -128,7 +129,8 @@ class APB4Cpuif(APB4CpuifFlat):
 
     def fanin_rd(self, node: AddressableNode | None = None, *, error: bool = False) -> str:
         fanin_rd = super().fanin_rd(node, error=error)
-        if node is not None and self.is_interface and node.is_array and node.array_dimensions:
+        if node is not None and self.is_interface and self.check_is_array(node):
+            assert node.array_dimensions is not None
             fanin: dict[str, str] = {}
             # Generate array index string [i0][i1]... for the intermediate signal
             array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))

--- a/src/peakrdl_busdecoder/cpuif/apb4/apb4_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/apb4/apb4_cpuif.py
@@ -45,7 +45,7 @@ class APB4CpuifFlat(BaseCpuif):
     def fanout(self, node: AddressableNode, array_stack: deque[int]) -> str:
         fanout: dict[str, str] = {}
 
-        addr_width = f"{self.exp.ds.module_name.upper()}_{node.inst_name.upper()}_ADDR_WIDTH"
+        addr_width = self.addr_width_param(node)
 
         sel_expr = (
             f"cpuif_wr_sel.{get_indexed_path(self.exp.ds.top_node, node, 'gi')}"
@@ -121,8 +121,8 @@ class APB4Cpuif(APB4CpuifFlat):
             fanin: dict[str, str] = {}
             # Generate array index string [i0][i1]... for the intermediate signal
             array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))
-            fanin["cpuif_wr_ack"] = f"{node.inst_name}_fanin_ready{array_idx}"
-            fanin["cpuif_wr_err"] = f"{node.inst_name}_fanin_err{array_idx}"
+            fanin["cpuif_wr_ack"] = f"{self.exp.ds.master_port_name(node)}_fanin_ready{array_idx}"
+            fanin["cpuif_wr_err"] = f"{self.exp.ds.master_port_name(node)}_fanin_err{array_idx}"
 
             fanin_wr = "\n" + "\n".join([f"{lhs} = {rhs};" for lhs, rhs in fanin.items()])
         return fanin_wr
@@ -134,9 +134,9 @@ class APB4Cpuif(APB4CpuifFlat):
             fanin: dict[str, str] = {}
             # Generate array index string [i0][i1]... for the intermediate signal
             array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))
-            fanin["cpuif_rd_ack"] = f"{node.inst_name}_fanin_ready{array_idx}"
-            fanin["cpuif_rd_err"] = f"{node.inst_name}_fanin_err{array_idx}"
-            fanin["cpuif_rd_data"] = f"{node.inst_name}_fanin_data{array_idx}"
+            fanin["cpuif_rd_ack"] = f"{self.exp.ds.master_port_name(node)}_fanin_ready{array_idx}"
+            fanin["cpuif_rd_err"] = f"{self.exp.ds.master_port_name(node)}_fanin_err{array_idx}"
+            fanin["cpuif_rd_data"] = f"{self.exp.ds.master_port_name(node)}_fanin_data{array_idx}"
 
             fanin_rd = "\n" + "\n".join([f"{lhs} = {rhs};" for lhs, rhs in fanin.items()])
         return fanin_rd

--- a/src/peakrdl_busdecoder/cpuif/axi4lite/axi4_lite_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/axi4lite/axi4_lite_cpuif.py
@@ -41,8 +41,8 @@ class AXI4LiteCpuifFlat(BaseCpuif):
 
     def fanout(self, node: AddressableNode, array_stack: deque[int]) -> str:
         fanout: dict[str, str] = {}
-        waddr_comp = [f"{self.signal('AWADDR')}", f"{SVInt(node.raw_absolute_address, self.addr_width)}"]
-        raddr_comp = [f"{self.signal('ARADDR')}", f"{SVInt(node.raw_absolute_address, self.addr_width)}"]
+        waddr_comp = [f"{self.signal('AWADDR')}", f"{SVInt(self.node_base_address(node), self.addr_width)}"]
+        raddr_comp = [f"{self.signal('ARADDR')}", f"{SVInt(self.node_base_address(node), self.addr_width)}"]
         for i, stride in enumerate(array_stack):
             offset = f"{self.addr_width}'(gi{i}*{SVInt(stride, self.addr_width)})"
             waddr_comp.append(offset)
@@ -128,7 +128,8 @@ class AXI4LiteCpuif(AXI4LiteCpuifFlat):
 
     def fanin_wr(self, node: AddressableNode | None = None, *, error: bool = False) -> str:
         fanin_wr = super().fanin_wr(node, error=error)
-        if node is not None and self.is_interface and node.is_array and node.array_dimensions:
+        if node is not None and self.is_interface and self.check_is_array(node):
+            assert node.array_dimensions is not None
             fanin: dict[str, str] = {}
             # Generate array index string [i0][i1]... for the intermediate signal
             array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))
@@ -141,7 +142,8 @@ class AXI4LiteCpuif(AXI4LiteCpuifFlat):
 
     def fanin_rd(self, node: AddressableNode | None = None, *, error: bool = False) -> str:
         fanin_rd = super().fanin_rd(node, error=error)
-        if node is not None and self.is_interface and node.is_array and node.array_dimensions:
+        if node is not None and self.is_interface and self.check_is_array(node):
+            assert node.array_dimensions is not None
             fanin: dict[str, str] = {}
             # Generate array index string [i0][i1]... for the intermediate signal
             array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))

--- a/src/peakrdl_busdecoder/cpuif/axi4lite/axi4_lite_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/axi4lite/axi4_lite_cpuif.py
@@ -48,7 +48,7 @@ class AXI4LiteCpuifFlat(BaseCpuif):
             waddr_comp.append(offset)
             raddr_comp.append(offset)
 
-        addr_width = f"{self.exp.ds.module_name.upper()}_{node.inst_name.upper()}_ADDR_WIDTH"
+        addr_width = self.addr_width_param(node)
 
         wr_sel = f"cpuif_wr_sel.{get_indexed_path(self.exp.ds.top_node, node, 'gi')}"
         rd_sel = f"cpuif_rd_sel.{get_indexed_path(self.exp.ds.top_node, node, 'gi')}"
@@ -133,8 +133,8 @@ class AXI4LiteCpuif(AXI4LiteCpuifFlat):
             fanin: dict[str, str] = {}
             # Generate array index string [i0][i1]... for the intermediate signal
             array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))
-            fanin["cpuif_wr_ack"] = f"{node.inst_name}_fanin_wr_valid{array_idx}"
-            fanin["cpuif_wr_err"] = f"{node.inst_name}_fanin_wr_err{array_idx}"
+            fanin["cpuif_wr_ack"] = f"{self.exp.ds.master_port_name(node)}_fanin_wr_valid{array_idx}"
+            fanin["cpuif_wr_err"] = f"{self.exp.ds.master_port_name(node)}_fanin_wr_err{array_idx}"
 
             fanin_wr = "\n" + "\n".join([f"{lhs} = {rhs};" for lhs, rhs in fanin.items()])
 
@@ -147,9 +147,9 @@ class AXI4LiteCpuif(AXI4LiteCpuifFlat):
             fanin: dict[str, str] = {}
             # Generate array index string [i0][i1]... for the intermediate signal
             array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))
-            fanin["cpuif_rd_ack"] = f"{node.inst_name}_fanin_ready{array_idx}"
-            fanin["cpuif_rd_err"] = f"{node.inst_name}_fanin_err{array_idx}"
-            fanin["cpuif_rd_data"] = f"{node.inst_name}_fanin_data{array_idx}"
+            fanin["cpuif_rd_ack"] = f"{self.exp.ds.master_port_name(node)}_fanin_ready{array_idx}"
+            fanin["cpuif_rd_err"] = f"{self.exp.ds.master_port_name(node)}_fanin_err{array_idx}"
+            fanin["cpuif_rd_data"] = f"{self.exp.ds.master_port_name(node)}_fanin_data{array_idx}"
 
             fanin_rd = "\n" + "\n".join([f"{lhs} = {rhs};" for lhs, rhs in fanin.items()])
 
@@ -173,6 +173,6 @@ class AXI4LiteCpuif(AXI4LiteCpuifFlat):
 
         array_str = "".join(f"[{dim}]" for dim in node.array_dimensions)
         return [
-            f"logic {node.inst_name}_fanin_wr_valid{array_str};",
-            f"logic {node.inst_name}_fanin_wr_err{array_str};",
+            f"logic {self.exp.ds.master_port_name(node)}_fanin_wr_valid{array_str};",
+            f"logic {self.exp.ds.master_port_name(node)}_fanin_wr_err{array_str};",
         ]

--- a/src/peakrdl_busdecoder/cpuif/base_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/base_cpuif.py
@@ -42,15 +42,20 @@ class BaseCpuif:
 
     @property
     def master_addr_widths(self) -> list[tuple[str, int]]:
-        """Per-master (INST_NAME, addr_width) pairs for package localparams.
+        """Per-master (PORT_NAME, addr_width) pairs for package localparams.
 
-        Deduplicated by instance name: unrolled array elements share one
-        localparam since every element has the same size.
+        Keyed by the (possibly path-qualified) master port name; unrolled
+        array elements share one localparam since every element has the
+        same size.
         """
         result: dict[str, int] = {}
         for child in self.addressable_children:
-            result.setdefault(child.inst_name.upper(), clog2(child.size))
+            result.setdefault(self.exp.ds.master_port_name(child).upper(), clog2(child.size))
         return list(result.items())
+
+    def addr_width_param(self, node: AddressableNode) -> str:
+        """Name of the package localparam holding this master's address width."""
+        return f"{self.exp.ds.module_name.upper()}_{self.exp.ds.master_port_name(node).upper()}_ADDR_WIDTH"
 
     @property
     def port_declaration(self) -> str:
@@ -85,7 +90,7 @@ class BaseCpuif:
             child_path = child.get_rel_path(ds.top_node)
             if child_path in enable_covered_paths:
                 continue
-            params.append(f"localparam N_{child.inst_name.upper()}S = {child.n_elements}")
+            params.append(f"localparam N_{ds.master_port_name(child).upper()}S = {child.n_elements}")
 
         # Address-modifying RDL parameters as SV module parameters
         for rdl_param in ds.enable_rdl_params:

--- a/src/peakrdl_busdecoder/cpuif/base_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/base_cpuif.py
@@ -41,6 +41,18 @@ class BaseCpuif:
         return self.data_width // 8
 
     @property
+    def master_addr_widths(self) -> list[tuple[str, int]]:
+        """Per-master (INST_NAME, addr_width) pairs for package localparams.
+
+        Deduplicated by instance name: unrolled array elements share one
+        localparam since every element has the same size.
+        """
+        result: dict[str, int] = {}
+        for child in self.addressable_children:
+            result.setdefault(child.inst_name.upper(), clog2(child.size))
+        return list(result.items())
+
+    @property
     def port_declaration(self) -> str:
         raise NotImplementedError()
 
@@ -99,6 +111,18 @@ class BaseCpuif:
             return False
         return node.is_array
 
+    @staticmethod
+    def node_base_address(node: AddressableNode) -> int:
+        """Base address of a fanout target relative to the address space root.
+
+        For an unrolled array element this is the element's own address; for a
+        rolled-up array it is the index-0 address (per-index strides are added
+        separately by the surrounding generate loops).
+        """
+        if node.current_idx is not None:
+            return node.absolute_address
+        return node.raw_absolute_address
+
     def get_implementation(self) -> str:
         class_dir = self._get_template_path_class_dir()
         loader = jj.FileSystemLoader(class_dir)
@@ -134,7 +158,7 @@ class BaseCpuif:
     def _can_truncate_addr(self, node: AddressableNode, array_stack: deque[int]) -> bool:
         if node.size.bit_count() != 1:
             return False
-        if node.raw_absolute_address % node.size != 0:
+        if self.node_base_address(node) % node.size != 0:
             return False
         for stride in array_stack:
             if stride % node.size != 0:

--- a/src/peakrdl_busdecoder/cpuif/fanin_gen.py
+++ b/src/peakrdl_busdecoder/cpuif/fanin_gen.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 
 
 class FaninGenerator(BusDecoderListener):
+    walk_unrolled = True
+
     def __init__(self, ds: DesignState, cpuif: "BaseCpuif") -> None:
         super().__init__(ds)
         self._cpuif = cpuif
@@ -28,11 +30,8 @@ class FaninGenerator(BusDecoderListener):
         action = super().enter_AddressableComponent(node)
         should_generate = action == WalkerAction.SkipDescendants
 
-        if not should_generate and self._ds.max_decode_depth == 0:
-            if not self._ds.node_meta(node).has_addressable_children:
-                should_generate = True
-
-        if node.array_dimensions:
+        if self.is_rolled_array(node):
+            assert node.array_dimensions is not None
             for i, dim in enumerate(node.array_dimensions):
                 fb = ForLoopBody(
                     "int",
@@ -55,7 +54,8 @@ class FaninGenerator(BusDecoderListener):
         return action
 
     def exit_AddressableComponent(self, node: AddressableNode) -> None:
-        if node.array_dimensions:
+        if self.is_rolled_array(node):
+            assert node.array_dimensions is not None
             for _ in node.array_dimensions:
                 b = self._stack.pop()
                 if not b:

--- a/src/peakrdl_busdecoder/cpuif/fanin_intermediate_gen.py
+++ b/src/peakrdl_busdecoder/cpuif/fanin_intermediate_gen.py
@@ -79,7 +79,7 @@ class FaninIntermediateGenerator(BusDecoderListener):
 
     def _generate_intermediate_declarations(self, node: AddressableNode) -> None:
         """Generate intermediate signal declarations for a node."""
-        inst_name = node.inst_name
+        inst_name = self._ds.master_port_name(node)
 
         # Array dimensions should be checked before calling this function
         if not node.array_dimensions:
@@ -107,8 +107,11 @@ class FaninIntermediateGenerator(BusDecoderListener):
 
     def _generate_intermediate_assignments(self, node: AddressableNode) -> str:
         """Generate assignments from interface array to intermediate signals."""
-        inst_name = node.inst_name
-        indexed_path = get_indexed_path(node.parent, node, "gi", skip_kw_filter=True)
+        inst_name = self._ds.master_port_name(node)
+        # Master interface reference: (possibly path-qualified) port base name
+        # plus the index expressions from the node's own path
+        raw_path = get_indexed_path(node.parent, node, "gi", skip_kw_filter=True)
+        indexed_path = inst_name + raw_path[len(node.inst_name) :]
 
         # Get master prefix - use getattr to avoid type errors
         interface = getattr(self._cpuif, "_interface", None)

--- a/src/peakrdl_busdecoder/cpuif/fanin_intermediate_gen.py
+++ b/src/peakrdl_busdecoder/cpuif/fanin_intermediate_gen.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
 class FaninIntermediateGenerator(BusDecoderListener):
     """Generates intermediate signals for interface array fanin."""
 
+    walk_unrolled = True
+
     def __init__(self, ds: DesignState, cpuif: "BaseCpuif") -> None:
         super().__init__(ds)
         self._cpuif = cpuif
@@ -35,10 +37,12 @@ class FaninIntermediateGenerator(BusDecoderListener):
         action = super().enter_AddressableComponent(node)
         should_generate = action == WalkerAction.SkipDescendants
 
-        # Only generate intermediates for interface arrays
+        # Only generate intermediates for rolled interface arrays. Unrolled
+        # elements are individual scalar interfaces that the fanin logic can
+        # reference directly.
         # Check if cpuif has is_interface attribute (some implementations don't)
         is_interface = getattr(self._cpuif, "is_interface", False)
-        if not is_interface or not node.array_dimensions:
+        if not is_interface or not self.is_rolled_array(node):
             return action
 
         # Generate intermediate signal declarations
@@ -63,7 +67,8 @@ class FaninIntermediateGenerator(BusDecoderListener):
 
     def exit_AddressableComponent(self, node: AddressableNode) -> None:
         is_interface = getattr(self._cpuif, "is_interface", False)
-        if is_interface and node.array_dimensions:
+        if is_interface and self.is_rolled_array(node):
+            assert node.array_dimensions is not None
             for _ in node.array_dimensions:
                 b = self._stack.pop()
                 if not b:

--- a/src/peakrdl_busdecoder/cpuif/fanout_gen.py
+++ b/src/peakrdl_busdecoder/cpuif/fanout_gen.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 
 class FanoutGenerator(BusDecoderListener):
+    walk_unrolled = True
+
     def __init__(self, ds: DesignState, cpuif: "BaseCpuif") -> None:
         super().__init__(ds)
         self._cpuif = cpuif
@@ -24,11 +26,9 @@ class FanoutGenerator(BusDecoderListener):
         action = super().enter_AddressableComponent(node)
 
         should_generate = action == WalkerAction.SkipDescendants
-        if not should_generate and self._ds.max_decode_depth == 0:
-            if not self._ds.node_meta(node).has_addressable_children:
-                should_generate = True
 
-        if node.array_dimensions:
+        if self.is_rolled_array(node):
+            assert node.array_dimensions is not None
             s_len = len(self._stack)
             for i, dim in enumerate(node.array_dimensions, s_len - 1):
                 fb = ForLoopBody(
@@ -44,7 +44,8 @@ class FanoutGenerator(BusDecoderListener):
         return action
 
     def exit_AddressableComponent(self, node: AddressableNode) -> None:
-        if node.array_dimensions:
+        if self.is_rolled_array(node):
+            assert node.array_dimensions is not None
             for _ in node.array_dimensions:
                 b = self._stack.pop()
                 if not b:

--- a/src/peakrdl_busdecoder/cpuif/interface.py
+++ b/src/peakrdl_busdecoder/cpuif/interface.py
@@ -18,6 +18,10 @@ class Interface(ABC):
     def __init__(self, cpuif: "BaseCpuif") -> None:
         self.cpuif = cpuif
 
+    def master_base_name(self, node: AddressableNode) -> str:
+        """Master port base name for a node (path-qualified on conflicts)."""
+        return self.cpuif.exp.ds.master_port_name(node)
+
     @property
     @abstractmethod
     def is_interface(self) -> bool:
@@ -77,7 +81,10 @@ class SVInterface(Interface):
         master_ports: list[str] = []
 
         for child in self.cpuif.addressable_children:
-            base = f"{self.get_interface_type()}.{self.master_modport_name} {master_prefix}{child.inst_name}"
+            base = (
+                f"{self.get_interface_type()}.{self.master_modport_name} "
+                f"{master_prefix}{self.master_base_name(child)}"
+            )
 
             # When unrolled, current_idx is set - append it to the name
             if child.current_idx is not None:
@@ -111,14 +118,18 @@ class SVInterface(Interface):
 
         # Master signal
         master_prefix = self.get_master_prefix()
+        base = self.master_base_name(node)
 
         if not self.cpuif.check_is_array(node) and node.current_idx is not None:
             # A specific element of an unrolled array: the master port is a
             # scalar interface named with an index suffix (e.g. m_apb_blk_0)
-            name = f"{node.inst_name}_{'_'.join(map(str, node.current_idx))}"
-            return f"{master_prefix}{name}.{signal}"
+            return f"{master_prefix}{base}_{'_'.join(map(str, node.current_idx))}.{signal}"
 
-        return f"{master_prefix}{get_indexed_path(node.parent, node, indexer, skip_kw_filter=True)}.{signal}"
+        # get_indexed_path relative to the parent yields the node's own name
+        # plus any index expressions; substitute the (possibly qualified) base
+        indexed = get_indexed_path(node.parent, node, indexer, skip_kw_filter=True)
+        suffix = indexed[len(node.inst_name) :]
+        return f"{master_prefix}{base}{suffix}.{signal}"
 
     @abstractmethod
     def get_interface_type(self) -> str:
@@ -167,7 +178,7 @@ class FlatInterface(Interface):
 
         # Master signal
         master_prefix = self.get_master_prefix()
-        base = f"{master_prefix}{node.inst_name}"
+        base = f"{master_prefix}{self.master_base_name(node)}"
 
         if not self.cpuif.check_is_array(node):
             # Not an array or an unrolled element
@@ -186,7 +197,7 @@ class FlatInterface(Interface):
                 return f"{base}_{signal}{''.join(indexes)}"
 
             return f"{base}_{signal}[{indexer}]"
-        return f"{base}_{signal}[N_{node.inst_name.upper()}S]"
+        return f"{base}_{signal}[N_{self.master_base_name(node).upper()}S]"
 
     @abstractmethod
     def _get_slave_port_declarations(self, slave_prefix: str) -> list[str]:

--- a/src/peakrdl_busdecoder/cpuif/interface.py
+++ b/src/peakrdl_busdecoder/cpuif/interface.py
@@ -111,6 +111,13 @@ class SVInterface(Interface):
 
         # Master signal
         master_prefix = self.get_master_prefix()
+
+        if not self.cpuif.check_is_array(node) and node.current_idx is not None:
+            # A specific element of an unrolled array: the master port is a
+            # scalar interface named with an index suffix (e.g. m_apb_blk_0)
+            name = f"{node.inst_name}_{'_'.join(map(str, node.current_idx))}"
+            return f"{master_prefix}{name}.{signal}"
+
         return f"{master_prefix}{get_indexed_path(node.parent, node, indexer, skip_kw_filter=True)}.{signal}"
 
     @abstractmethod

--- a/src/peakrdl_busdecoder/decode_logic_gen.py
+++ b/src/peakrdl_busdecoder/decode_logic_gen.py
@@ -95,11 +95,6 @@ class DecodeLogicGenerator(BusDecoderListener):
         action = super().enter_AddressableComponent(node)
         should_decode = action == WalkerAction.SkipDescendants
 
-        if not should_decode and self._ds.max_decode_depth == 0:
-            # When decoding all levels, treat leaf registers as decode boundary
-            if not self._ds.node_meta(node).has_addressable_children:
-                should_decode = True
-
         conditions: list[str] = []
         conditions.extend(self.cpuif_addr_predicate(node))
         conditions.extend(self.cpuif_prot_predicate(node))
@@ -129,6 +124,8 @@ class DecodeLogicGenerator(BusDecoderListener):
 
     def exit_AddressableComponent(self, node: AddressableNode) -> None:
         if not node.array_dimensions:
+            # Still unwind the base class depth/stride bookkeeping
+            super().exit_AddressableComponent(node)
             return
 
         ifb = self._decode_stack.pop()

--- a/src/peakrdl_busdecoder/design_state.py
+++ b/src/peakrdl_busdecoder/design_state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import TypedDict
 
 from systemrdl.node import AddressableNode, AddrmapNode
@@ -120,7 +121,13 @@ class DesignState:
             self._enable_params_by_node_dim = {}
 
     def node_meta(self, node: AddressableNode) -> NodeMeta:
-        return self._node_meta[node.get_path()]
+        path = node.get_path()
+        meta = self._node_meta.get(path)
+        if meta is None:
+            # Unrolled element nodes carry concrete indices in their path
+            # ("blk[2]"), but the scanner records rolled-up paths ("blk[]").
+            meta = self._node_meta[re.sub(r"\[\d+\]", "[]", path)]
+        return meta
 
     def get_enable_param_for_dimension(self, node: AddressableNode, dim_index: int) -> RdlParameter | None:
         """
@@ -143,10 +150,18 @@ class DesignState:
         Get addressable children at the decode boundary based on max_decode_depth.
 
         max_decode_depth semantics:
-        - 0: decode all levels (return leaf registers)
-        - 1: decode only top level (return children at depth 1)
-        - 2: decode top + 1 level (return children at depth 2)
-        - N: decode down to depth N (return children at depth N)
+        - 0: decode all levels (descend as deep as possible)
+        - 1: decode only top level (children at depth 1)
+        - N: decode down to depth N
+
+        A node is a decode boundary when any of these hold, matching the rules
+        the walker-based generators apply in ``BusDecoderListener.should_skip_node``
+        (the port list and the decode/fanout/fanin logic must always agree on
+        the same set of nodes):
+
+        - it sits at ``max_decode_depth`` (when a depth limit is set),
+        - it has no addressable children (a register, memory, or empty block),
+        - it is a block whose addressable children are all external.
 
         Args:
             unroll: Whether to unroll arrayed nodes
@@ -161,31 +176,27 @@ class DesignState:
         if cached is not None:
             return cached
 
+        def is_boundary(node: AddressableNode, current_depth: int) -> bool:
+            if self.max_decode_depth > 0 and current_depth >= self.max_decode_depth:
+                return True
+
+            # Compute child facts directly: unrolled nodes are not present in
+            # the scanner's node_meta cache (their paths carry indices).
+            addressable_children = [c for c in node.children() if isinstance(c, AddressableNode)]
+            if not addressable_children:
+                return True
+            if not isinstance(node, RegNode) and all(c.external for c in addressable_children):
+                return True
+            return False
+
         def collect_nodes(node: AddressableNode, current_depth: int) -> list[AddressableNode]:
-            """Recursively collect nodes at the decode boundary."""
+            if is_boundary(node, current_depth):
+                return [node]
+
             result: list[AddressableNode] = []
-
-            # For depth 0, collect all leaf registers
-            if self.max_decode_depth == 0:
-                # If this is a register, it's a leaf
-                if isinstance(node, RegNode):
-                    result.append(node)
-                else:
-                    # Recurse into children
-                    for child in node.children(unroll=unroll):
-                        if isinstance(child, AddressableNode):
-                            result.extend(collect_nodes(child, current_depth + 1))
-            else:
-                # For depth N, collect children at depth N
-                if current_depth == self.max_decode_depth:
-                    # We're at the decode boundary - return this node
-                    result.append(node)
-                elif current_depth < self.max_decode_depth:
-                    # We haven't reached the boundary yet - recurse
-                    for child in node.children(unroll=unroll):
-                        if isinstance(child, AddressableNode):
-                            result.extend(collect_nodes(child, current_depth + 1))
-
+            for child in node.children(unroll=unroll):
+                if isinstance(child, AddressableNode):
+                    result.extend(collect_nodes(child, current_depth + 1))
             return result
 
         # Start collecting from top node's children

--- a/src/peakrdl_busdecoder/design_state.py
+++ b/src/peakrdl_busdecoder/design_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections import defaultdict
 from typing import TypedDict
 
 from systemrdl.node import AddressableNode, AddrmapNode
@@ -64,6 +65,11 @@ class DesignState:
         # Scan the design to fill in above variables
         DesignScanner(self).do_scan()
 
+        # Pre-label master port names for the decode boundary: instance name
+        # by default, path-qualified when siblings elsewhere in the hierarchy
+        # would otherwise collide on the same port name.
+        self._master_port_names = self._compute_master_port_names()
+
         if self.cpuif_data_width == 0:
             # Scanner did not find any registers in the design being exported,
             # so the width is not known.
@@ -119,6 +125,45 @@ class DesignState:
             self.rdl_params = []
             self.enable_rdl_params = []
             self._enable_params_by_node_dim = {}
+
+    @staticmethod
+    def _normalized_path(node: AddressableNode) -> str:
+        """Node path with concrete array indices rolled up, so every element
+        of an unrolled array shares one key."""
+        return re.sub(r"\[\d+\]", "[]", node.get_path())
+
+    def _compute_master_port_names(self) -> dict[str, str]:
+        """Label every decode-boundary node with its master port base name.
+
+        The base name is the instance name. When two boundary nodes under
+        different parents share an instance name (e.g. two regfiles that each
+        contain a register named ``status``), every member of the colliding
+        group is qualified with its path relative to the top node
+        (``blk_a_status``, ``blk_b_status``) so the generated ports stay
+        unique. Index suffixes/dimensions for arrays are appended separately
+        by the interface layer.
+        """
+        groups: dict[str, dict[str, AddressableNode]] = defaultdict(dict)
+        for child in self.get_addressable_children_at_depth(unroll=self.cpuif_unroll):
+            # Keyed by rolled-up path: elements of one array are one master
+            groups[child.inst_name][self._normalized_path(child)] = child
+
+        names: dict[str, str] = {}
+        for inst_name, nodes in groups.items():
+            if len(nodes) == 1:
+                names[next(iter(nodes))] = inst_name
+            else:
+                for key, node in nodes.items():
+                    rel_path = node.get_rel_path(self.top_node, empty_array_suffix="")
+                    names[key] = re.sub(r"\[[^\]]*\]", "", rel_path).replace(".", "_")
+        return names
+
+    def master_port_name(self, node: AddressableNode) -> str:
+        """Master port base name for a decode-boundary node.
+
+        Falls back to the instance name for nodes outside the boundary map.
+        """
+        return self._master_port_names.get(self._normalized_path(node), node.inst_name)
 
     def node_meta(self, node: AddressableNode) -> NodeMeta:
         path = node.get_path()

--- a/src/peakrdl_busdecoder/exporter.py
+++ b/src/peakrdl_busdecoder/exporter.py
@@ -137,7 +137,10 @@ class BusDecoderExporter:
         stream.dump(module_file_path)
 
     def walk(self, listener_cls: type[BusDecoderListener], **kwargs: dict[str, Any]) -> str:
-        walker = RDLSteerableWalker()
+        # Port-referencing listeners walk unrolled when cpuif_unroll is set, so
+        # each array element is fanned out/in as an individual master port.
+        unroll = self.ds.cpuif_unroll and listener_cls.walk_unrolled
+        walker = RDLSteerableWalker(unroll=unroll)
         listener = listener_cls(self.ds, **kwargs)
         walker.walk(self.ds.top_node, listener, skip_top=True)
         return str(listener)

--- a/src/peakrdl_busdecoder/listener.py
+++ b/src/peakrdl_busdecoder/listener.py
@@ -7,10 +7,19 @@ from .design_state import DesignState
 
 
 class BusDecoderListener(RDLListener):
+    # When True and the design is exported with cpuif_unroll, the exporter
+    # walks this listener with arrays unrolled so each element is visited as
+    # an individual (scalar) master.
+    walk_unrolled = False
+
     def __init__(self, ds: DesignState) -> None:
         self._array_stride_stack: deque[int] = deque()  # Tracks nested array strides
         self._ds = ds
         self._depth = 0
+
+    def is_rolled_array(self, node: AddressableNode) -> bool:
+        """True for an arrayed node visited rolled-up (not an unrolled element)."""
+        return bool(node.array_dimensions) and node.current_idx is None
 
     def should_skip_node(self, node: AddressableNode) -> bool:
         """Check if this node should be skipped (not decoded)."""
@@ -28,11 +37,16 @@ class BusDecoderListener(RDLListener):
             if self._ds.node_meta(node).has_only_external_addressable_children:
                 return True
 
+        # A leaf addressable node (register, memory, empty block) is always a
+        # decode boundary, even when it sits shallower than max_decode_depth.
+        if node != self._ds.top_node and not self._ds.node_meta(node).has_addressable_children:
+            return True
+
         return False
 
     def enter_AddressableComponent(self, node: AddressableNode) -> WalkerAction | None:
         meta = self._ds.node_meta(node)
-        if meta.array_strides is not None:
+        if meta.array_strides is not None and self.is_rolled_array(node):
             strides = meta.array_strides
             self._array_stride_stack.append(strides[0])
             for stride in strides[1:]:
@@ -47,7 +61,8 @@ class BusDecoderListener(RDLListener):
         return WalkerAction.Continue
 
     def exit_AddressableComponent(self, node: AddressableNode) -> None:
-        if node.array_dimensions:
+        if self.is_rolled_array(node):
+            assert node.array_dimensions is not None
             for _ in node.array_dimensions:
                 self._array_stride_stack.pop()
 

--- a/src/peakrdl_busdecoder/package_tmpl.sv
+++ b/src/peakrdl_busdecoder/package_tmpl.sv
@@ -13,8 +13,8 @@ package {{ds.package_name}};
     localparam {{ds.module_name.upper()}}_DATA_WIDTH = {{ds.cpuif_data_width}};
     localparam {{ds.module_name.upper()}}_MIN_ADDR_WIDTH = {{ds.addr_width}};
     localparam {{ds.module_name.upper()}}_SIZE = {{SVInt(ds.top_node.size)}};
-{%- for child in cpuif.addressable_children %}
-    localparam {{ds.module_name.upper()}}_{{child.inst_name.upper()}}_ADDR_WIDTH = {{child.size|clog2}};
+{%- for name, width in cpuif.master_addr_widths %}
+    localparam {{ds.module_name.upper()}}_{{name}}_ADDR_WIDTH = {{width}};
 {%- endfor %}
 {%- for param in ds.enable_rdl_params %}
     localparam {{ds.module_name.upper()}}_MAX_{{param.name}} = {{param.value}};

--- a/src/peakrdl_busdecoder/validate_design.py
+++ b/src/peakrdl_busdecoder/validate_design.py
@@ -30,8 +30,35 @@ class DesignValidator(RDLListener):
 
     def do_validate(self) -> None:
         RDLWalker().walk(self.top_node, self)
+        self._check_unique_master_port_names()
         if self.msg.had_error:
             self.msg.fatal("Unable to export due to previous errors")
+
+    def _check_unique_master_port_names(self) -> None:
+        """Reject designs whose decode boundary produces colliding master ports.
+
+        Master ports are named after the boundary node's instance name only, so
+        two boundary nodes with the same instance name under different parents
+        (e.g. two regfiles that each contain a register named ``status``) would
+        silently generate a module with duplicate port declarations.
+        """
+        seen: dict[str, AddressableNode] = {}
+        for child in self.ds.get_addressable_children_at_depth(unroll=self.ds.cpuif_unroll):
+            name = child.inst_name
+            if child.current_idx is not None:
+                name += "_" + "_".join(map(str, child.current_idx))
+
+            other = seen.get(name)
+            if other is not None:
+                self.msg.error(
+                    f"Instances '{other.get_rel_path(self.top_node)}' and "
+                    f"'{child.get_rel_path(self.top_node)}' both resolve to master port "
+                    f"name '{name}'. Rename one of the instances, or lower "
+                    "max_decode_depth so the decode boundary stops above them.",
+                    child.inst.inst_src_ref,
+                )
+            else:
+                seen[name] = child
 
     def enter_Component(self, node: "Node") -> WalkerAction | None:
         if node.external and (node != self.top_node):

--- a/src/peakrdl_busdecoder/validate_design.py
+++ b/src/peakrdl_busdecoder/validate_design.py
@@ -35,16 +35,17 @@ class DesignValidator(RDLListener):
             self.msg.fatal("Unable to export due to previous errors")
 
     def _check_unique_master_port_names(self) -> None:
-        """Reject designs whose decode boundary produces colliding master ports.
+        """Backstop: reject designs whose master port names still collide.
 
-        Master ports are named after the boundary node's instance name only, so
-        two boundary nodes with the same instance name under different parents
-        (e.g. two regfiles that each contain a register named ``status``) would
-        silently generate a module with duplicate port declarations.
+        Boundary nodes whose instance names conflict are automatically
+        path-qualified (see ``DesignState._compute_master_port_names``), so
+        this only fires in pathological cases where even the qualified names
+        coincide (e.g. instances ``a.b_c`` and ``a_b.c``, or an instance whose
+        literal name matches another's qualified name).
         """
         seen: dict[str, AddressableNode] = {}
         for child in self.ds.get_addressable_children_at_depth(unroll=self.ds.cpuif_unroll):
-            name = child.inst_name
+            name = self.ds.master_port_name(child)
             if child.current_idx is not None:
                 name += "_" + "_".join(map(str, child.current_idx))
 
@@ -53,8 +54,9 @@ class DesignValidator(RDLListener):
                 self.msg.error(
                     f"Instances '{other.get_rel_path(self.top_node)}' and "
                     f"'{child.get_rel_path(self.top_node)}' both resolve to master port "
-                    f"name '{name}'. Rename one of the instances, or lower "
-                    "max_decode_depth so the decode boundary stops above them.",
+                    f"name '{name}' even after path qualification. Rename one of the "
+                    "instances, or lower max_decode_depth so the decode boundary stops "
+                    "above them.",
                     child.inst.inst_src_ref,
                 )
             else:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,64 @@
+"""Fixtures for cross-block integration tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from systemrdl.node import AddrmapNode
+from typing_extensions import Unpack
+
+from peakrdl_busdecoder import BusDecoderExporter
+from peakrdl_busdecoder.exporter import ExporterKwargs
+
+
+@dataclass
+class ExportedDesign:
+    """A compiled + exported design and everything needed to inspect it."""
+
+    top: AddrmapNode
+    exporter: BusDecoderExporter
+    module_text: str
+    package_text: str
+
+
+@pytest.fixture
+def export_design(compile_rdl: Callable[..., AddrmapNode], tmp_path: Path) -> Callable[..., ExportedDesign]:
+    """Compile inline RDL and export it, returning the generated output.
+
+    Usage::
+
+        design = export_design(rdl_source, top="soc", cpuif_cls=APB4Cpuif)
+    """
+    counter = 0
+
+    def _export(
+        rdl_source: str,
+        *,
+        top: str,
+        **exporter_kwargs: Unpack[ExporterKwargs],
+    ) -> ExportedDesign:
+        nonlocal counter
+        counter += 1
+        top_node = compile_rdl(rdl_source, top=top)
+
+        output_dir = tmp_path / f"export_{counter}"
+        module_name = exporter_kwargs.get("module_name", top_node.inst_name)
+        package_name = exporter_kwargs.get("package_name", f"{module_name}_pkg")
+
+        exporter = BusDecoderExporter()
+        exporter.export(top_node, str(output_dir), **exporter_kwargs)
+
+        module_text = (output_dir / f"{module_name}.sv").read_text()
+        package_text = (output_dir / f"{package_name}.sv").read_text()
+
+        return ExportedDesign(
+            top=top_node,
+            exporter=exporter,
+            module_text=module_text,
+            package_text=package_text,
+        )
+
+    return _export

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,348 @@
+"""Helpers for cross-block integration tests.
+
+These utilities extract *structural facts* from generated SystemVerilog so
+tests can cross-check the different generator stages (ports, select struct,
+address decoder, fanout, fanin, package) against each other and against the
+compiled SystemRDL address map.
+
+The address decoder is additionally *evaluated* in Python: :func:`route`
+walks the parsed if/else + for-loop structure for a concrete address and
+returns which select signals fire. This lets tests verify end-to-end routing
+behavior (address in -> block select out) without an HDL simulator.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from itertools import product
+
+from systemrdl.node import AddressableNode, AddrmapNode, MemNode, RegNode
+
+# ---------------------------------------------------------------------------
+# Decode logic parsing / evaluation
+# ---------------------------------------------------------------------------
+
+_RE_IF = re.compile(r"^if \((?P<cond>.*)\) begin$")
+_RE_ELSE_IF = re.compile(r"^end else if \((?P<cond>.*)\) begin$")
+_RE_ELSE = re.compile(r"^end else begin$")
+_RE_FOR = re.compile(r"^for \(int (?P<var>\w+) = 0; (?P=var) < (?P<bound>\d+); (?P=var)\+\+\) begin$")
+_RE_END = re.compile(r"^end$")
+_RE_ASSIGN = re.compile(r"^cpuif_(?:wr|rd)_sel\.(?P<target>[\w.\[\]]+) = 1'b1;$")
+
+# SystemVerilog expression -> Python expression rewrites
+_RE_WIDTH_CAST = re.compile(r"(\d+)'\(")  # 14'( ... )  -> _wcast(14, ... )
+_RE_HEX = re.compile(r"(?:\d+)?'h([0-9a-fA-F_]+)")
+_RE_DEC = re.compile(r"(?:\d+)?'d([0-9_]+)")
+_RE_BIN = re.compile(r"(?:\d+)?'b([01_]+)")
+
+
+def _sv_expr_to_python(expr: str) -> str:
+    expr = _RE_WIDTH_CAST.sub(r"_wcast(\1,", expr)
+    expr = _RE_HEX.sub(lambda m: str(int(m.group(1).replace("_", ""), 16)), expr)
+    expr = _RE_DEC.sub(lambda m: m.group(1).replace("_", ""), expr)
+    expr = _RE_BIN.sub(lambda m: str(int(m.group(1).replace("_", ""), 2)), expr)
+    expr = expr.replace("&&", " and ").replace("||", " or ")
+    return expr
+
+
+@dataclass
+class DecodeAssign:
+    """One ``cpuif_*_sel.<target> = 1'b1;`` statement and its guards."""
+
+    target: str  # e.g. "uarts[i0]", "rf_a.ra", "cpuif_err"
+    conditions: list[str] = field(default_factory=list)  # python exprs, all must hold
+    loops: list[tuple[str, int]] = field(default_factory=list)  # enclosing (var, bound)
+
+
+@dataclass
+class _Frame:
+    kind: str  # "cond" or "loop"
+    cond: str | None = None  # python expr of the taken branch (None for plain else)
+    prior: list[str] = field(default_factory=list)  # negated earlier branches
+    loop: tuple[str, int] | None = None
+
+    def guards(self) -> list[str]:
+        result = [f"not ({c})" for c in self.prior]
+        if self.cond is not None:
+            result.append(self.cond)
+        return result
+
+
+def parse_decode_assigns(module_text: str, flavor: str) -> list[DecodeAssign]:
+    """Parse the read or write address decoder into a list of guarded assigns.
+
+    Parameters
+    ----------
+    module_text:
+        Full text of the generated module.
+    flavor:
+        ``"wr"`` or ``"rd"``.
+    """
+    marker = {"wr": "// Write Address Decoder", "rd": "// Read Address Decoder"}[flavor]
+    start = module_text.index(marker)
+    body = module_text[start:]
+    body = body[body.index("always_comb begin") + len("always_comb begin") :]
+
+    assigns: list[DecodeAssign] = []
+    stack: list[_Frame] = []
+
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("//"):
+            continue
+
+        if m := _RE_FOR.match(line):
+            stack.append(_Frame(kind="loop", loop=(m.group("var"), int(m.group("bound")))))
+        elif m := _RE_IF.match(line):
+            stack.append(_Frame(kind="cond", cond=_sv_expr_to_python(m.group("cond"))))
+        elif m := _RE_ELSE_IF.match(line):
+            frame = stack[-1]
+            assert frame.kind == "cond", f"unexpected 'else if' nesting near: {line}"
+            assert frame.cond is not None
+            frame.prior.append(frame.cond)
+            frame.cond = _sv_expr_to_python(m.group("cond"))
+        elif _RE_ELSE.match(line):
+            frame = stack[-1]
+            assert frame.kind == "cond", f"unexpected 'else' nesting near: {line}"
+            assert frame.cond is not None
+            frame.prior.append(frame.cond)
+            frame.cond = None
+        elif _RE_END.match(line):
+            if not stack:
+                # closed the always_comb block itself; decoder is done
+                break
+            stack.pop()
+        elif m := _RE_ASSIGN.match(line):
+            conditions: list[str] = []
+            loops: list[tuple[str, int]] = []
+            for frame in stack:
+                if frame.kind == "loop":
+                    assert frame.loop is not None
+                    loops.append(frame.loop)
+                else:
+                    conditions.extend(frame.guards())
+            assigns.append(DecodeAssign(m.group("target"), conditions, loops))
+        # anything else (default '{...} assignment, endmodule, ...) is ignored
+
+    return assigns
+
+
+def route(assigns: list[DecodeAssign], addr: int) -> list[str]:
+    """Evaluate the parsed decoder for one address.
+
+    Returns the list of select targets that fire, with loop indices resolved,
+    e.g. ``["uarts[1]"]`` or ``["cpuif_err"]``. An empty list means the
+    address is dead: no block is selected and no error is flagged.
+    """
+    base_env = {
+        "_wcast": lambda width, value: value & ((1 << width) - 1),
+        "cpuif_req": 1,
+        "cpuif_wr_en": 1,
+        "cpuif_rd_en": 1,
+        "cpuif_wr_addr": addr,
+        "cpuif_rd_addr": addr,
+    }
+
+    fired: list[str] = []
+    for assign in assigns:
+        loop_vars = [var for var, _ in assign.loops]
+        bounds = [bound for _, bound in assign.loops]
+        for indices in product(*(range(b) for b in bounds)):
+            env = dict(base_env, **dict(zip(loop_vars, indices, strict=True)))
+            if all(eval(cond, {"__builtins__": {}}, env) for cond in assign.conditions):
+                target = assign.target
+                for var, value in zip(loop_vars, indices, strict=True):
+                    target = target.replace(f"[{var}]", f"[{value}]")
+                fired.append(target)
+    return fired
+
+
+# ---------------------------------------------------------------------------
+# Module structure parsing
+# ---------------------------------------------------------------------------
+
+_RE_INTF_MASTER_PORT = re.compile(
+    r"^\s*\w+_intf\.master\s+m_(?:apb|axil)_(?P<name>\w+)\s*(?P<dims>(?:\[\w+\]\s*)*),?\s*$",
+    re.MULTILINE,
+)
+_RE_LOCALPARAM = re.compile(r"localparam\s+(?P<name>\w+)\s*=\s*(?P<value>[^;,)\s]+)")
+_RE_DIM = re.compile(r"\[(\w+)\]")
+
+
+def _resolve_dim(dim: str, localparams: dict[str, int]) -> int:
+    return int(dim) if dim.isdigit() else localparams[dim]
+
+
+def parse_module_localparams(module_text: str) -> dict[str, int]:
+    """Extract integer localparams declared in the module header."""
+    header = module_text[: module_text.index(");")]
+    params: dict[str, int] = {}
+    for m in _RE_LOCALPARAM.finditer(header):
+        value = m.group("value")
+        if value.isdigit():
+            params[m.group("name")] = int(value)
+    return params
+
+
+def parse_interface_master_ports(module_text: str) -> dict[str, tuple[int, ...]]:
+    """Return master interface ports as ``{name: dims}`` (name has bus prefix stripped).
+
+    Duplicate port names are surfaced via a trailing ``#<n>`` suffix so tests
+    can assert on (absence of) collisions.
+    """
+    header = module_text[: module_text.index(");")]
+    localparams = parse_module_localparams(module_text)
+    ports: dict[str, tuple[int, ...]] = {}
+    for m in _RE_INTF_MASTER_PORT.finditer(header):
+        name = m.group("name")
+        dims = tuple(_resolve_dim(d, localparams) for d in _RE_DIM.findall(m.group("dims")))
+        if name in ports:
+            suffix = 2
+            while f"{name}#{suffix}" in ports:
+                suffix += 1
+            name = f"{name}#{suffix}"
+        ports[name] = dims
+    return ports
+
+
+def parse_flat_master_ports(module_text: str, select_signal: str) -> dict[str, tuple[int, ...]]:
+    """Return flat-style master ports as ``{name: dims}``.
+
+    Masters are identified by their select/valid signal (``PSEL`` for APB,
+    ``AWVALID`` for AXI4-Lite) to count each master exactly once.
+    """
+    header = module_text[: module_text.index(");")]
+    localparams = parse_module_localparams(module_text)
+    pattern = re.compile(
+        rf"^\s*output\s+logic\s+m_(?:apb|axil)_(?P<name>\w+)_{select_signal}"
+        rf"(?P<dims>(?:\[\w+\])*)\s*,?\s*$",
+        re.MULTILINE,
+    )
+    ports: dict[str, tuple[int, ...]] = {}
+    for m in pattern.finditer(header):
+        dims = tuple(_resolve_dim(d, localparams) for d in _RE_DIM.findall(m.group("dims")))
+        ports[m.group("name")] = dims
+    return ports
+
+
+def parse_sel_struct_leaves(module_text: str) -> dict[str, tuple[int, ...]]:
+    """Expand the ``cpuif_sel_t`` typedef tree into ``{leaf_path: dims}``.
+
+    Nested struct typedefs (``cpuif_sel_<inst>_t``) are expanded recursively,
+    e.g. ``{"rf_a.ra": (), "rf_b.rc": (2,)}``. The ``cpuif_err`` field is
+    excluded.
+    """
+    typedefs: dict[str, list[tuple[str, str, tuple[int, ...]]]] = {}
+    for m in re.finditer(r"typedef struct \{(?P<body>.*?)\} (?P<name>\w+);", module_text, re.DOTALL):
+        fields: list[tuple[str, str, tuple[int, ...]]] = []
+        for fm in re.finditer(r"(?P<type>\w+)\s+(?P<name>\w+)(?P<dims>(?:\[\d+\])*);", m.group("body")):
+            dims = tuple(int(d) for d in _RE_DIM.findall(fm.group("dims")))
+            fields.append((fm.group("type"), fm.group("name"), dims))
+        typedefs[m.group("name")] = fields
+
+    leaves: dict[str, tuple[int, ...]] = {}
+
+    def expand(typedef_name: str, prefix: str, outer_dims: tuple[int, ...]) -> None:
+        for field_type, field_name, dims in typedefs[typedef_name]:
+            path = f"{prefix}{field_name}"
+            if field_type in typedefs:
+                expand(field_type, f"{path}.", outer_dims + dims)
+            elif field_name != "cpuif_err":
+                leaves[path] = outer_dims + dims
+
+    expand("cpuif_sel_t", "", ())
+    return leaves
+
+
+def parse_fanout_masters(module_text: str) -> set[str]:
+    """Master instance names referenced by the fanout stage (interface style)."""
+    start = module_text.index("// Fanout CPU Bus interface signals")
+    end = module_text.index("// Fanin CPU Bus interface signals")
+    section = module_text[start:end]
+    return {m.group(1) for m in re.finditer(r"assign m_(?:apb|axil)_(\w+?)(?:\[\w+\])*\.", section)}
+
+
+def parse_fanin_sel_paths(module_text: str) -> set[str]:
+    """Select-struct paths consumed by the fanin stage (indices stripped)."""
+    start = module_text.index("// Fanin CPU Bus interface signals")
+    section = module_text[start:]
+    end = section.index("// Write Address Decoder")
+    section = section[:end]
+    paths = {
+        re.sub(r"\[\w+\]", "", m.group(1))
+        for m in re.finditer(r"if \(cpuif_(?:wr|rd)_sel\.([\w.\[\]]+)\)", section)
+    }
+    return paths - {"cpuif_err"}
+
+
+def parse_package_localparams(package_text: str) -> dict[str, int]:
+    """Extract ``localparam NAME = value;`` entries from the generated package."""
+    params: dict[str, int] = {}
+    for m in re.finditer(r"localparam\s+(\w+)\s*=\s*([^;]+);", package_text):
+        value = m.group(2).strip()
+        params[m.group(1)] = int(_sv_expr_to_python(value), 0)
+    return params
+
+
+# ---------------------------------------------------------------------------
+# SystemRDL ground-truth oracle
+# ---------------------------------------------------------------------------
+
+
+def occupied_extent(node: AddressableNode) -> int:
+    """Bytes from a node's base address to the end of its last implemented leaf.
+
+    The generated decoder bounds each block by its *occupied* extent (end of
+    the last register/memory), not by the declared size of the component.
+    """
+    if isinstance(node, (RegNode, MemNode)):
+        return node.size
+
+    ends = []
+    for child in node.children(unroll=False):
+        if not isinstance(child, AddressableNode):
+            continue
+        end = child.raw_address_offset + occupied_extent(child)
+        if child.is_array:
+            assert child.array_stride is not None
+            end += child.array_stride * (child.n_elements - 1)
+        ends.append(end)
+    return max(ends) if ends else node.size
+
+
+def top_level_blocks(top: AddrmapNode) -> list[AddressableNode]:
+    """Addressable children directly under the exported top node (rolled-up)."""
+    return [c for c in top.children(unroll=False) if isinstance(c, AddressableNode)]
+
+
+def iter_reg_expectations(top: AddrmapNode) -> list[tuple[int, str]]:
+    """Yield ``(relative_address, expected_select_target)`` for every register.
+
+    The expected target is the decoder select for the *top-level* block
+    enclosing the register (default ``max_decode_depth=1`` semantics),
+    including array indices, e.g. ``uarts[1]`` or ``ctrl``.
+    """
+    expectations: list[tuple[int, str]] = []
+
+    def visit(node: AddressableNode) -> None:
+        for child in node.children(unroll=True):
+            if not isinstance(child, AddressableNode):
+                continue
+            if isinstance(child, RegNode):
+                # Find the ancestor that is a direct child of top
+                block: AddressableNode = child
+                while block.parent is not top:
+                    parent = block.parent
+                    assert isinstance(parent, AddressableNode)
+                    block = parent
+                target = block.inst_name
+                for idx in block.current_idx or []:
+                    target += f"[{idx}]"
+                rel_addr = child.absolute_address - top.absolute_address
+                expectations.append((rel_addr, target))
+            else:
+                visit(child)
+
+    visit(top)
+    return expectations

--- a/tests/integration/test_cross_block_flow.py
+++ b/tests/integration/test_cross_block_flow.py
@@ -1,0 +1,233 @@
+"""End-to-end flow tests over a heterogeneous multi-block design.
+
+Rather than exercising each generator class in isolation, these tests export
+one realistic SoC-style address map (arrayed external block, scalar external
+block, a bare register, an external memory) and verify that the *whole*
+generated decoder is coherent:
+
+* every register address routes to the select of its enclosing block,
+* addresses outside any block never select a block,
+* the read and write decoders implement the same map,
+* module ports, select struct, fanout, fanin, and decoder all agree on the
+  set of downstream blocks,
+* package parameters match the compiled address map,
+* every CPU interface flavor implements the same decode.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+
+import pytest
+
+from peakrdl_busdecoder.cpuif.apb3 import APB3Cpuif
+from peakrdl_busdecoder.cpuif.apb3.apb3_cpuif import APB3CpuifFlat
+from peakrdl_busdecoder.cpuif.apb4 import APB4Cpuif
+from peakrdl_busdecoder.cpuif.apb4.apb4_cpuif import APB4CpuifFlat
+from peakrdl_busdecoder.cpuif.axi4lite import AXI4LiteCpuif
+from peakrdl_busdecoder.cpuif.axi4lite.axi4_lite_cpuif import AXI4LiteCpuifFlat
+from peakrdl_busdecoder.utils import clog2
+
+from .conftest import ExportedDesign
+from .helpers import (
+    iter_reg_expectations,
+    occupied_extent,
+    parse_decode_assigns,
+    parse_fanin_sel_paths,
+    parse_fanout_masters,
+    parse_flat_master_ports,
+    parse_interface_master_ports,
+    parse_package_localparams,
+    parse_sel_struct_leaves,
+    route,
+    top_level_blocks,
+)
+
+# A heterogeneous SoC-style map: an arrayed external block, a scalar external
+# block, a plain register, and an external memory — with gaps between them.
+SOC_RDL = """
+addrmap uart {
+    reg { field { sw=rw; hw=r; } data[7:0]; } tx @ 0x0;
+    reg { field { sw=r;  hw=w; } data[7:0]; } rx @ 0x4;
+    reg { field { sw=rw; hw=r; } div[15:0]; } baud @ 0x8;
+};
+
+addrmap dma {
+    reg { field { sw=rw; hw=r; } addr[31:0]; } src @ 0x0;
+    reg { field { sw=rw; hw=r; } addr[31:0]; } dst @ 0x4;
+    reg { field { sw=rw; hw=r; } len[15:0]; } xfer @ 0x8;
+};
+
+mem buf_t {
+    mementries = 64;
+    memwidth = 32;
+};
+
+addrmap soc {
+    external uart  uarts[2] @ 0x0000 += 0x100;
+    external dma   dma0     @ 0x1000;
+    reg { field { sw=rw; hw=r; } v[31:0]; } ctrl @ 0x2000;
+    external buf_t buffer   @ 0x3000;
+};
+"""
+
+INTERFACE_CPUIFS = [
+    pytest.param(APB3Cpuif, id="apb3"),
+    pytest.param(APB4Cpuif, id="apb4"),
+    pytest.param(AXI4LiteCpuif, id="axi4lite"),
+]
+
+FLAT_CPUIFS = [
+    pytest.param(APB3CpuifFlat, "PSEL", id="apb3-flat"),
+    pytest.param(APB4CpuifFlat, "PSEL", id="apb4-flat"),
+    pytest.param(AXI4LiteCpuifFlat, "AWVALID", id="axi4lite-flat"),
+]
+
+
+@pytest.fixture(params=INTERFACE_CPUIFS)
+def soc(request: pytest.FixtureRequest, export_design: Callable[..., ExportedDesign]) -> ExportedDesign:
+    return export_design(SOC_RDL, top="soc", cpuif_cls=request.param)
+
+
+class TestAddressRouting:
+    """Feed concrete addresses through the parsed decoder and check the target."""
+
+    @pytest.mark.parametrize("flavor", ["wr", "rd"])
+    def test_every_register_address_routes_to_its_block(self, soc: ExportedDesign, flavor: str) -> None:
+        assigns = parse_decode_assigns(soc.module_text, flavor)
+        expectations = iter_reg_expectations(soc.top)
+        assert expectations, "oracle found no registers — bad test design"
+
+        for addr, expected_target in expectations:
+            assert route(assigns, addr) == [expected_target], (
+                f"address {addr:#x} should select {expected_target}"
+            )
+
+    @pytest.mark.parametrize("flavor", ["wr", "rd"])
+    def test_memory_block_is_selected_across_its_full_size(self, soc: ExportedDesign, flavor: str) -> None:
+        assigns = parse_decode_assigns(soc.module_text, flavor)
+        # buffer: 64 entries x 32 bits at 0x3000
+        assert route(assigns, 0x3000) == ["buffer"]
+        assert route(assigns, 0x30FC) == ["buffer"]  # last word
+        assert route(assigns, 0x3100) == ["cpuif_err"]  # one past the end
+
+    @pytest.mark.parametrize("flavor", ["wr", "rd"])
+    def test_addresses_outside_any_block_never_select_a_block(self, soc: ExportedDesign, flavor: str) -> None:
+        assigns = parse_decode_assigns(soc.module_text, flavor)
+        gap_addresses = [
+            0x000C,  # tail of uarts[0], before uarts[1]
+            0x010C,  # tail of uarts[1], within the array span
+            0x0200,  # between the uarts array span and dma0
+            0x0FFC,  # just before dma0
+            0x100C,  # just past dma0's last register
+            0x2004,  # just past ctrl
+            0x2FFC,  # just before buffer
+            0x3FFC,  # top of the address space
+        ]
+        for addr in gap_addresses:
+            targets = route(assigns, addr)
+            blocks = [t for t in targets if t != "cpuif_err"]
+            assert not blocks, f"gap address {addr:#x} unexpectedly selected {blocks}"
+
+    def test_read_and_write_decoders_implement_the_same_map(self, soc: ExportedDesign) -> None:
+        wr = parse_decode_assigns(soc.module_text, "wr")
+        rd = parse_decode_assigns(soc.module_text, "rd")
+
+        def normalize(assigns: list) -> list:
+            return [(a.target, [c.replace("_rd_", "_wr_") for c in a.conditions], a.loops) for a in assigns]
+
+        assert normalize(wr) == normalize(rd)
+
+
+class TestCrossGeneratorConsistency:
+    """The independently generated module sections must agree on the block set."""
+
+    def test_ports_struct_decode_fanout_fanin_agree(self, soc: ExportedDesign) -> None:
+        expected = {
+            block.inst_name: tuple(block.array_dimensions or ()) for block in top_level_blocks(soc.top)
+        }
+
+        ports = parse_interface_master_ports(soc.module_text)
+        sel_leaves = parse_sel_struct_leaves(soc.module_text)
+        fanout = parse_fanout_masters(soc.module_text)
+        fanin = parse_fanin_sel_paths(soc.module_text)
+        decode_targets = {
+            re.sub(r"\[\w+\]", "", a.target)
+            for a in parse_decode_assigns(soc.module_text, "wr")
+            if a.target != "cpuif_err"
+        }
+
+        assert ports == expected
+        assert sel_leaves == expected
+        assert fanout == set(expected)
+        assert fanin == set(expected)
+        assert decode_targets == set(expected)
+
+    @pytest.mark.parametrize(("cpuif_cls", "select_signal"), FLAT_CPUIFS)
+    def test_flat_ports_agree_with_decode(
+        self,
+        export_design: Callable[..., ExportedDesign],
+        cpuif_cls: type,
+        select_signal: str,
+    ) -> None:
+        design = export_design(SOC_RDL, top="soc", cpuif_cls=cpuif_cls)
+        expected = {
+            block.inst_name: tuple(block.array_dimensions or ()) for block in top_level_blocks(design.top)
+        }
+
+        ports = parse_flat_master_ports(design.module_text, select_signal)
+        decode_targets = {
+            re.sub(r"\[\w+\]", "", a.target)
+            for a in parse_decode_assigns(design.module_text, "wr")
+            if a.target != "cpuif_err"
+        }
+
+        assert ports == expected
+        assert decode_targets == set(expected)
+
+    def test_decode_logic_is_identical_across_all_cpuifs(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        all_cpuifs = [
+            APB3Cpuif,
+            APB3CpuifFlat,
+            APB4Cpuif,
+            APB4CpuifFlat,
+            AXI4LiteCpuif,
+            AXI4LiteCpuifFlat,
+        ]
+        decoders = []
+        for cpuif_cls in all_cpuifs:
+            design = export_design(SOC_RDL, top="soc", cpuif_cls=cpuif_cls)
+            decoders.append(parse_decode_assigns(design.module_text, "wr"))
+
+        reference = decoders[0]
+        assert reference, "reference decoder parsed as empty"
+        for cpuif_cls, decoder in zip(all_cpuifs[1:], decoders[1:], strict=True):
+            assert decoder == reference, f"{cpuif_cls.__name__} decodes differently"
+
+
+class TestPackageConsistency:
+    """The generated package must describe the same address map as the module."""
+
+    def test_package_parameters_match_compiled_address_map(self, soc: ExportedDesign) -> None:
+        params = parse_package_localparams(soc.package_text)
+        top = soc.top
+        prefix = top.inst_name.upper()
+
+        assert params[f"{prefix}_DATA_WIDTH"] == 32
+        assert params[f"{prefix}_SIZE"] == top.size
+        assert params[f"{prefix}_MIN_ADDR_WIDTH"] == clog2(top.size)
+
+        for block in top_level_blocks(top):
+            name = f"{prefix}_{block.inst_name.upper()}_ADDR_WIDTH"
+            assert params[name] == clog2(occupied_extent(block)), name
+
+    def test_module_address_signals_match_package_width(self, soc: ExportedDesign) -> None:
+        params = parse_package_localparams(soc.package_text)
+        addr_width = params[f"{soc.top.inst_name.upper()}_MIN_ADDR_WIDTH"]
+
+        m = re.search(r"logic \[(\d+):0\] cpuif_wr_addr;", soc.module_text)
+        assert m is not None
+        assert int(m.group(1)) + 1 == addr_width

--- a/tests/integration/test_hierarchy_flow.py
+++ b/tests/integration/test_hierarchy_flow.py
@@ -4,12 +4,11 @@ These exercise combinations where several generator stages must cooperate:
 multi-dimensional arrays, decode boundaries inside regfiles, sibling blocks
 at deeper decode depths, and CPU-interface unrolling.
 
-Tests marked ``xfail(strict=True)`` document *known* cross-generator
-inconsistencies found while building this suite: the port list is derived
-from ``DesignState.get_addressable_children_at_depth`` while the decoder,
-select struct, and fanout come from walker-based generators with different
-boundary rules. When the underlying bug is fixed, the strict xfail will flip
-and the test can be promoted to a plain assertion.
+Several of these are regression tests for cross-generator inconsistencies
+found while building this suite, where the port list (from
+``DesignState.get_addressable_children_at_depth``) disagreed with the
+decoder/select-struct/fanout walkers about where the decode boundary sits.
+Both sides now share the same boundary rules; these tests pin that down.
 """
 
 from __future__ import annotations
@@ -116,23 +115,21 @@ class TestRegfileHierarchy:
         ports = parse_interface_master_ports(design.module_text)
         assert {"ra", "rb"} <= set(ports)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Known bug: an arrayed register at the max_decode_depth boundary is "
-            "decoded as its whole parent regfile (`cpuif_wr_sel.rf_b = 1'b1;`, an "
-            "invalid struct-to-bit assignment) while ports and the select struct "
-            "expose the per-element `rc[2]` array."
-        ),
-    )
     def test_depth2_routes_arrayed_regfile_registers_per_element(
         self, export_design: Callable[..., ExportedDesign]
     ) -> None:
+        """Regression: the decoder used to leak its depth counter and select the
+        whole parent regfile (`cpuif_wr_sel.rf_b = 1'b1;`, an invalid
+        struct-to-bit assignment) instead of the per-element `rc` array."""
         design = export_design(REGFILE_RDL, top="rfsoc", max_decode_depth=2)
         assigns = parse_decode_assigns(design.module_text, "wr")
 
         assert route(assigns, 0x100) == ["rf_b.rc[0]"]
         assert route(assigns, 0x104) == ["rf_b.rc[1]"]
+
+        ports = parse_interface_master_ports(design.module_text)
+        assert ports == {"ra": (), "rb": (), "rc": (2,)}
+        assert parse_fanout_masters(design.module_text) == set(ports)
 
     def test_depth0_full_decode_is_internally_consistent(
         self, export_design: Callable[..., ExportedDesign]
@@ -157,18 +154,13 @@ class TestRegfileHierarchy:
 class TestDeepSiblingBlocks:
     """Sibling addrmaps at max_decode_depth=2 with identically named children."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Known bug: with sibling addrmap blocks at max_decode_depth=2, the "
-            "port list descends to leaf addrmaps (emitting duplicate "
-            "`m_apb_leaf0`/`m_apb_leaf1` ports) while decode/fanout stop at the "
-            "mid-level blocks and reference undeclared `m_apb_mid_*` ports."
-        ),
-    )
     def test_depth2_ports_agree_with_decode_targets(
         self, export_design: Callable[..., ExportedDesign]
     ) -> None:
+        """Regression: the port list used to descend past the all-external
+        boundary into the leaf addrmaps (emitting duplicate `m_apb_leaf0`/
+        `m_apb_leaf1` ports) while decode/fanout stopped at the mid-level
+        blocks and referenced undeclared `m_apb_mid_*` ports."""
         design = export_design(SIBLING_RDL, top="topblk", max_decode_depth=2)
 
         ports = parse_interface_master_ports(design.module_text)
@@ -179,20 +171,15 @@ class TestDeepSiblingBlocks:
             for a in parse_decode_assigns(design.module_text, "wr")
             if a.target != "cpuif_err"
         }
-        assert set(ports) == decode_targets
-        assert parse_fanout_masters(design.module_text) <= set(ports)
+        assert set(ports) == decode_targets == {"mid_a", "mid_b", "zero_reg"}
+        assert parse_fanout_masters(design.module_text) == set(ports)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Known bug: a register that sits shallower than max_decode_depth "
-            "(here zero_reg at depth 1 with depth=2) is decoded and fanned out "
-            "but silently dropped from the module's port list."
-        ),
-    )
     def test_depth2_keeps_ports_for_shallow_registers(
         self, export_design: Callable[..., ExportedDesign]
     ) -> None:
+        """Regression: a register shallower than max_decode_depth (zero_reg at
+        depth 1 with depth=2) used to be silently dropped from the port list,
+        leaving its addresses unreachable."""
         design = export_design(SIBLING_RDL, top="topblk", max_decode_depth=2)
 
         assigns = parse_decode_assigns(design.module_text, "wr")
@@ -203,26 +190,31 @@ class TestDeepSiblingBlocks:
 
 
 class TestCpuifUnroll:
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Known bug: with cpuif_unroll=True the port list unrolls arrays into "
-            "`m_apb_uarts_0`/`m_apb_uarts_1`, but fanout still drives the rolled "
-            "`m_apb_uarts[gi0]` interface array and the select struct keeps "
-            "`uarts[2]` — the generated module does not elaborate."
-        ),
-    )
+    """cpuif_unroll semantics: master ports are unrolled into scalar
+    interfaces (`m_apb_uarts_0`), while the internal select struct and
+    decoder stay rolled (`uarts[2]` + for-loops). Fanout/fanin bridge the
+    two with constant indices (`cpuif_wr_sel.uarts[0]` -> `m_apb_uarts_0`).
+
+    Regression: fanout used to drive the rolled `m_apb_uarts[gi0]` interface
+    array, which was never declared as a port, so the module did not
+    elaborate."""
+
     def test_unrolled_ports_agree_with_fanout_and_struct(
         self, export_design: Callable[..., ExportedDesign]
     ) -> None:
         design = export_design(UNROLL_RDL, top="unroll_soc", cpuif_unroll=True)
 
         ports = parse_interface_master_ports(design.module_text)
-        fanout = parse_fanout_masters(design.module_text)
-        assert fanout <= set(ports)
+        assert ports == {"uarts_0": (), "uarts_1": (), "ctrl": ()}
 
+        fanout = parse_fanout_masters(design.module_text)
+        assert fanout == set(ports)
+
+        # The select struct stays rolled; fanout indexes it with constants
         sel_leaves = parse_sel_struct_leaves(design.module_text)
-        assert set(sel_leaves) == set(ports)
+        assert sel_leaves == {"uarts": (2,), "ctrl": ()}
+        assert "cpuif_wr_sel.uarts[0]|cpuif_rd_sel.uarts[0]" in design.module_text
+        assert "m_apb_uarts[" not in design.module_text
 
     def test_unrolled_decode_still_routes_correctly(
         self, export_design: Callable[..., ExportedDesign]
@@ -233,3 +225,37 @@ class TestCpuifUnroll:
         assert route(assigns, 0x000) == ["uarts[0]"]
         assert route(assigns, 0x100) == ["uarts[1]"]
         assert route(assigns, 0x1000) == ["ctrl"]
+
+    def test_unrolled_fanin_reads_scalar_interfaces_directly(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(UNROLL_RDL, top="unroll_soc", cpuif_unroll=True)
+
+        # Each element is a scalar interface, so no fanin intermediate
+        # signals are needed and none may be left undriven.
+        assert "uarts_fanin_ready" not in design.module_text
+        assert "m_apb_uarts_0.PREADY" in design.module_text
+        assert "m_apb_uarts_1.PREADY" in design.module_text
+
+
+class TestPortNameCollisions:
+    def test_colliding_boundary_names_are_rejected(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        """Two boundary nodes with the same instance name under different
+        parents would generate duplicate master ports; the exporter must
+        reject the design instead of emitting uncompilable SystemVerilog."""
+        rdl = """
+        addrmap collide {
+            regfile {
+                reg { field { sw=rw; hw=r; } d[31:0]; } status @ 0x0;
+            } blk_a @ 0x0;
+            regfile {
+                reg { field { sw=rw; hw=r; } d[31:0]; } status @ 0x0;
+            } blk_b @ 0x100;
+        };
+        """
+        from systemrdl import RDLCompileError
+
+        with pytest.raises(RDLCompileError):
+            export_design(rdl, top="collide", max_decode_depth=2)

--- a/tests/integration/test_hierarchy_flow.py
+++ b/tests/integration/test_hierarchy_flow.py
@@ -239,12 +239,67 @@ class TestCpuifUnroll:
 
 
 class TestPortNameCollisions:
-    def test_colliding_boundary_names_are_rejected(
+    COLLIDE_RDL = """
+    addrmap collide {
+        regfile {
+            reg { field { sw=rw; hw=r; } d[31:0]; } status @ 0x0;
+        } blk_a @ 0x0;
+        regfile {
+            reg { field { sw=rw; hw=r; } d[31:0]; } status @ 0x0;
+            reg { field { sw=rw; hw=r; } d[31:0]; } irq[2] @ 0x10 += 0x4;
+        } blk_b @ 0x100;
+        regfile {
+            reg { field { sw=rw; hw=r; } d[31:0]; } irq[2] @ 0x0 += 0x4;
+        } blk_c @ 0x200;
+    };
+    """
+
+    def test_colliding_boundary_names_are_path_qualified(
         self, export_design: Callable[..., ExportedDesign]
     ) -> None:
-        """Two boundary nodes with the same instance name under different
-        parents would generate duplicate master ports; the exporter must
-        reject the design instead of emitting uncompilable SystemVerilog."""
+        """Boundary nodes with the same instance name under different parents
+        get path-qualified master ports instead of colliding declarations."""
+        design = export_design(self.COLLIDE_RDL, top="collide", max_decode_depth=2)
+
+        ports = parse_interface_master_ports(design.module_text)
+        assert ports == {
+            "blk_a_status": (),
+            "blk_b_status": (),
+            "blk_b_irq": (2,),
+            "blk_c_irq": (2,),
+        }
+        assert parse_fanout_masters(design.module_text) == set(ports)
+
+        # Decode/select stay hierarchical; only the port namespace is flattened
+        assigns = parse_decode_assigns(design.module_text, "wr")
+        assert route(assigns, 0x000) == ["blk_a.status"]
+        assert route(assigns, 0x100) == ["blk_b.status"]
+        assert route(assigns, 0x110) == ["blk_b.irq[0]"]
+        assert route(assigns, 0x204) == ["blk_c.irq[1]"]
+
+        # Qualified names carry through to array params, address-width
+        # params, and fanin intermediate signals
+        assert "N_BLK_B_IRQS" in design.module_text
+        assert "COLLIDE_BLK_A_STATUS_ADDR_WIDTH" in design.package_text
+        assert "blk_b_irq_fanin_ready" in design.module_text
+        assert "m_apb_status" not in design.module_text
+        assert "m_apb_irq " not in design.module_text
+
+    def test_non_conflicting_names_stay_unqualified(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(REGFILE_RDL, top="rfsoc", max_decode_depth=2)
+        assert parse_interface_master_ports(design.module_text) == {
+            "ra": (),
+            "rb": (),
+            "rc": (2,),
+        }
+
+    def test_pathological_collisions_are_still_rejected(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        """If a literal instance name matches another node's qualified name,
+        qualification cannot help and the exporter must reject the design."""
         rdl = """
         addrmap collide {
             regfile {
@@ -253,6 +308,7 @@ class TestPortNameCollisions:
             regfile {
                 reg { field { sw=rw; hw=r; } d[31:0]; } status @ 0x0;
             } blk_b @ 0x100;
+            reg { field { sw=rw; hw=r; } d[31:0]; } blk_a_status @ 0x200;
         };
         """
         from systemrdl import RDLCompileError

--- a/tests/integration/test_hierarchy_flow.py
+++ b/tests/integration/test_hierarchy_flow.py
@@ -1,0 +1,235 @@
+"""Cross-block flow tests for hierarchical, arrayed, and unrolled designs.
+
+These exercise combinations where several generator stages must cooperate:
+multi-dimensional arrays, decode boundaries inside regfiles, sibling blocks
+at deeper decode depths, and CPU-interface unrolling.
+
+Tests marked ``xfail(strict=True)`` document *known* cross-generator
+inconsistencies found while building this suite: the port list is derived
+from ``DesignState.get_addressable_children_at_depth`` while the decoder,
+select struct, and fanout come from walker-based generators with different
+boundary rules. When the underlying bug is fixed, the strict xfail will flip
+and the test can be promoted to a plain assertion.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+
+import pytest
+
+from .conftest import ExportedDesign
+from .helpers import (
+    iter_reg_expectations,
+    parse_decode_assigns,
+    parse_fanout_masters,
+    parse_interface_master_ports,
+    parse_sel_struct_leaves,
+    route,
+)
+
+GRID_RDL = """
+addrmap tile {
+    reg { field { sw=rw; hw=r; } d[31:0]; } r0 @ 0x0;
+    reg { field { sw=rw; hw=r; } d[31:0]; } r1 @ 0x4;
+};
+
+addrmap grid {
+    external tile tiles[2][3] @ 0x0 += 0x100;
+};
+"""
+
+REGFILE_RDL = """
+addrmap rfsoc {
+    regfile {
+        reg { field { sw=rw; hw=r; } d[31:0]; } ra @ 0x0;
+        reg { field { sw=rw; hw=r; } d[31:0]; } rb @ 0x4;
+    } rf_a @ 0x0;
+
+    regfile {
+        reg { field { sw=rw; hw=r; } d[31:0]; } rc[2] @ 0x0 += 0x4;
+    } rf_b @ 0x100;
+};
+"""
+
+SIBLING_RDL = """
+addrmap leafblk {
+    reg { field { sw=rw; hw=r; } d[31:0]; } r0 @ 0x0;
+    reg { field { sw=rw; hw=r; } d[31:0]; } r1 @ 0x4;
+};
+
+addrmap midblk {
+    leafblk leaf0 @ 0x0;
+    leafblk leaf1 @ 0x100;
+};
+
+addrmap topblk {
+    midblk mid_a @ 0x0000;
+    midblk mid_b @ 0x1000;
+    reg { field { sw=rw; hw=r; } d[31:0]; } zero_reg @ 0x2000;
+};
+"""
+
+UNROLL_RDL = """
+addrmap uart {
+    reg { field { sw=rw; hw=r; } data[7:0]; } tx @ 0x0;
+};
+
+addrmap unroll_soc {
+    external uart uarts[2] @ 0x0 += 0x100;
+    reg { field { sw=rw; hw=r; } v[31:0]; } ctrl @ 0x1000;
+};
+"""
+
+
+class TestMultiDimensionalArrays:
+    def test_2d_array_elements_route_by_index(self, export_design: Callable[..., ExportedDesign]) -> None:
+        design = export_design(GRID_RDL, top="grid")
+        assigns = parse_decode_assigns(design.module_text, "wr")
+
+        expectations = iter_reg_expectations(design.top)
+        assert len(expectations) == 2 * 3 * 2  # 6 tiles x 2 regs
+        for addr, expected_target in expectations:
+            assert route(assigns, addr) == [expected_target], (
+                f"address {addr:#x} should select {expected_target}"
+            )
+
+    def test_2d_array_ports_and_struct_keep_both_dimensions(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(GRID_RDL, top="grid")
+        assert parse_interface_master_ports(design.module_text) == {"tiles": (2, 3)}
+        assert parse_sel_struct_leaves(design.module_text) == {"tiles": (2, 3)}
+
+
+class TestRegfileHierarchy:
+    def test_depth2_routes_individual_regfile_registers(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(REGFILE_RDL, top="rfsoc", max_decode_depth=2)
+        assigns = parse_decode_assigns(design.module_text, "wr")
+
+        assert route(assigns, 0x0) == ["rf_a.ra"]
+        assert route(assigns, 0x4) == ["rf_a.rb"]
+
+        ports = parse_interface_master_ports(design.module_text)
+        assert {"ra", "rb"} <= set(ports)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Known bug: an arrayed register at the max_decode_depth boundary is "
+            "decoded as its whole parent regfile (`cpuif_wr_sel.rf_b = 1'b1;`, an "
+            "invalid struct-to-bit assignment) while ports and the select struct "
+            "expose the per-element `rc[2]` array."
+        ),
+    )
+    def test_depth2_routes_arrayed_regfile_registers_per_element(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(REGFILE_RDL, top="rfsoc", max_decode_depth=2)
+        assigns = parse_decode_assigns(design.module_text, "wr")
+
+        assert route(assigns, 0x100) == ["rf_b.rc[0]"]
+        assert route(assigns, 0x104) == ["rf_b.rc[1]"]
+
+    def test_depth0_full_decode_is_internally_consistent(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(REGFILE_RDL, top="rfsoc", max_decode_depth=0)
+        assigns = parse_decode_assigns(design.module_text, "wr")
+
+        assert route(assigns, 0x0) == ["rf_a.ra"]
+        assert route(assigns, 0x4) == ["rf_a.rb"]
+        assert route(assigns, 0x100) == ["rf_b.rc[0]"]
+        assert route(assigns, 0x104) == ["rf_b.rc[1]"]
+        assert route(assigns, 0x8) == ["cpuif_err"]
+
+        # Ports are named after the leaf registers; the select struct keeps
+        # the full hierarchical path. Leaf names and shapes must line up.
+        ports = parse_interface_master_ports(design.module_text)
+        sel_leaves = parse_sel_struct_leaves(design.module_text)
+        assert ports == {path.rsplit(".", 1)[-1]: dims for path, dims in sel_leaves.items()}
+        assert parse_fanout_masters(design.module_text) == set(ports)
+
+
+class TestDeepSiblingBlocks:
+    """Sibling addrmaps at max_decode_depth=2 with identically named children."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Known bug: with sibling addrmap blocks at max_decode_depth=2, the "
+            "port list descends to leaf addrmaps (emitting duplicate "
+            "`m_apb_leaf0`/`m_apb_leaf1` ports) while decode/fanout stop at the "
+            "mid-level blocks and reference undeclared `m_apb_mid_*` ports."
+        ),
+    )
+    def test_depth2_ports_agree_with_decode_targets(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(SIBLING_RDL, top="topblk", max_decode_depth=2)
+
+        ports = parse_interface_master_ports(design.module_text)
+        assert not any("#" in name for name in ports), f"duplicate ports: {ports}"
+
+        decode_targets = {
+            re.sub(r"\[\w+\]", "", a.target)
+            for a in parse_decode_assigns(design.module_text, "wr")
+            if a.target != "cpuif_err"
+        }
+        assert set(ports) == decode_targets
+        assert parse_fanout_masters(design.module_text) <= set(ports)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Known bug: a register that sits shallower than max_decode_depth "
+            "(here zero_reg at depth 1 with depth=2) is decoded and fanned out "
+            "but silently dropped from the module's port list."
+        ),
+    )
+    def test_depth2_keeps_ports_for_shallow_registers(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(SIBLING_RDL, top="topblk", max_decode_depth=2)
+
+        assigns = parse_decode_assigns(design.module_text, "wr")
+        assert route(assigns, 0x2000) == ["zero_reg"]  # decoder handles it...
+
+        ports = parse_interface_master_ports(design.module_text)
+        assert "zero_reg" in ports  # ...so the module must expose its port
+
+
+class TestCpuifUnroll:
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Known bug: with cpuif_unroll=True the port list unrolls arrays into "
+            "`m_apb_uarts_0`/`m_apb_uarts_1`, but fanout still drives the rolled "
+            "`m_apb_uarts[gi0]` interface array and the select struct keeps "
+            "`uarts[2]` — the generated module does not elaborate."
+        ),
+    )
+    def test_unrolled_ports_agree_with_fanout_and_struct(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(UNROLL_RDL, top="unroll_soc", cpuif_unroll=True)
+
+        ports = parse_interface_master_ports(design.module_text)
+        fanout = parse_fanout_masters(design.module_text)
+        assert fanout <= set(ports)
+
+        sel_leaves = parse_sel_struct_leaves(design.module_text)
+        assert set(sel_leaves) == set(ports)
+
+    def test_unrolled_decode_still_routes_correctly(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(UNROLL_RDL, top="unroll_soc", cpuif_unroll=True)
+        assigns = parse_decode_assigns(design.module_text, "wr")
+
+        assert route(assigns, 0x000) == ["uarts[0]"]
+        assert route(assigns, 0x100) == ["uarts[1]"]
+        assert route(assigns, 0x1000) == ["ctrl"]

--- a/tests/unit/test_max_decode_depth.py
+++ b/tests/unit/test_max_decode_depth.py
@@ -224,13 +224,16 @@ def test_depth_3_with_deep_hierarchy(compile_rdl: Callable[..., AddrmapNode]) ->
     content = _export_and_read(top, max_decode_depth=3)
 
     # Should have interfaces at depth 3: reg2, inner3
-    # (reg1 is at depth 2, not 3)
     assert "m_apb_reg2" in content
     assert "m_apb_inner3" in content
-    # Should NOT have interfaces at other depths
+    # reg1 is a leaf at depth 2, shallower than the boundary. It is still part
+    # of the address map, so it must keep its interface (previously it was
+    # silently dropped, leaving its addresses unreachable).
+    assert "m_apb_reg1" in content
+    # Should NOT have interfaces for non-leaf blocks above the boundary, nor
+    # for anything below it
     assert "m_apb_inner1" not in content
     assert "m_apb_inner2" not in content
-    assert "m_apb_reg1" not in content
     assert "m_apb_reg3" not in content
 
 
@@ -1297,35 +1300,50 @@ class TestComplexHierarchies:
         """depth=0 on a multi-branch hierarchy reaches all leaves.
 
         Each intermediate addrmap has a register to avoid the 'all external
-        children' skip logic.
+        children' skip logic. Register names are unique across the hierarchy
+        because master ports are named after the leaf instance name.
         """
         rdl_source = """
-        addrmap leaf {
-            reg { field { sw=rw; hw=r; } data[31:0]; } leaf_r @ 0x0;
+        addrmap leaf_a_t {
+            reg { field { sw=rw; hw=r; } data[31:0]; } leaf_ra @ 0x0;
+        };
+        addrmap leaf_b_t {
+            reg { field { sw=rw; hw=r; } data[31:0]; } leaf_rb @ 0x0;
         };
 
-        addrmap mid {
-            reg { field { sw=rw; hw=r; } data[31:0]; } mid_r @ 0x0;
-            leaf leaf_a @ 0x10;
-            leaf leaf_b @ 0x20;
+        addrmap mid_a_t {
+            reg { field { sw=rw; hw=r; } data[31:0]; } mid_ra @ 0x0;
+            leaf_a_t leaf_aa @ 0x10;
+            leaf_b_t leaf_ab @ 0x20;
+        };
+        addrmap leaf_c_t {
+            reg { field { sw=rw; hw=r; } data[31:0]; } leaf_rc @ 0x0;
+        };
+        addrmap mid_b_t {
+            reg { field { sw=rw; hw=r; } data[31:0]; } mid_rb @ 0x0;
+            leaf_c_t leaf_ba @ 0x10;
         };
 
         addrmap top {
-            mid side_a @ 0x0;
-            mid side_b @ 0x100;
+            mid_a_t side_a @ 0x0;
+            mid_b_t side_b @ 0x100;
         };
         """
         top = compile_rdl(rdl_source, top="top")
         content = _export_and_read(top, max_decode_depth=0)
 
-        # All leaf_r and mid_r instances should be referenced
-        assert "m_apb_leaf_r" in content
-        assert "m_apb_mid_r" in content
+        # All leaf registers should be referenced
+        assert "m_apb_leaf_ra" in content
+        assert "m_apb_leaf_rb" in content
+        assert "m_apb_leaf_rc" in content
+        assert "m_apb_mid_ra" in content
+        assert "m_apb_mid_rb" in content
         # No intermediate interfaces
         assert "m_apb_side_a" not in content
         assert "m_apb_side_b" not in content
-        assert "m_apb_leaf_a" not in content
-        assert "m_apb_leaf_b" not in content
+        assert "m_apb_leaf_aa" not in content
+        assert "m_apb_leaf_ab" not in content
+        assert "m_apb_leaf_ba" not in content
 
 
 # ===========================================================================


### PR DESCRIPTION
The existing unit tests exercise each generator class in isolation and
mostly assert on substrings of the output. This adds tests/integration/,
which exports whole multi-block designs and checks that the generated
module works as a coherent system:

- A Python evaluator for the generated address decoder (helpers.route)
  feeds concrete addresses through the parsed if/else + for-loop
  structure and asserts every register address selects its enclosing
  block (and gap addresses select nothing), with expectations derived
  from the compiled SystemRDL tree rather than hardcoded strings.
- Cross-generator consistency checks: module ports, the cpuif_sel
  struct, fanout, fanin, decode targets, and package localparams must
  all agree on the same set of downstream blocks, for all six CPUIF
  flavors (APB3/APB4/AXI4-Lite, interface and flat).
- Hierarchy coverage: 2D arrays, regfile decode boundaries at
  max_decode_depth 2 and 0, sibling blocks, and cpuif_unroll.

Building the suite surfaced four real cross-generator bugs, documented
as strict xfails so they flip loudly when fixed:
- max_decode_depth=2 with sibling addrmap blocks emits duplicate leaf
  ports while decode/fanout reference undeclared mid-level ports
- registers shallower than max_decode_depth are decoded but dropped
  from the port list
- an arrayed register at the decode boundary is decoded as its whole
  parent regfile (invalid struct-to-bit assignment)
- cpuif_unroll=True unrolls ports but fanout still drives the rolled
  interface array

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TMFtybV4NhYwyMKNwVLkGn