### PR TITLE
fix: remove unused ty suppression that fails typecheck CI on main

### DIFF
--- a/src/peakrdl_busdecoder/exporter.py
+++ b/src/peakrdl_busdecoder/exporter.py
@@ -99,7 +99,7 @@ class BusDecoderExporter:
         else:
             top_node = node
 
-        self.ds = DesignState(top_node, kwargs)  # ty: ignore
+        self.ds = DesignState(top_node, kwargs)
 
         cpuif_cls: type[BaseCpuif] = kwargs.pop("cpuif_cls", None) or APB4Cpuif
 


### PR DESCRIPTION
# Description of change

The typecheck workflow is currently red on `main` (run on 323fbd4): the `DesignState` changes merged in #68 made the blanket `# ty: ignore` on `exporter.py:102` unnecessary, and `ty` reports unused suppressions as errors. Every PR branched from main inherits the failure (first seen on #69).

One-line fix: drop the stale suppression. Verified `uv sync --extra cli && uvx ty check src/` passes clean, and the full non-simulation test suite still passes (247 passed).

The same commit is cherry-picked onto #69 so it can go green independently of merge order; it deduplicates on merge.

# Checklist

- [x] I have reviewed this project's [contribution guidelines](https://github.com/arnavsacheti/PeakRDL-BusDecoder/blob/main/CONTRIBUTING.md)
- [x] This change has been tested and does not break any of the existing unit tests.
- [x] If this change adds new features, I have added new unit tests that cover them. (n/a — removes a stale lint suppression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMFtybV4NhYwyMKNwVLkGn

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMFtybV4NhYwyMKNwVLkGn)_