### PR TITLE
fix: correct decode boundaries below rolled array ancestors

### DIFF
--- a/src/peakrdl_busdecoder/cpuif/apb3/apb3_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/apb3/apb3_cpuif.py
@@ -114,11 +114,10 @@ class APB3Cpuif(APB3CpuifFlat):
 
     def fanin_wr(self, node: AddressableNode | None = None, *, error: bool = False) -> str:
         fanin_wr = super().fanin_wr(node, error=error)
-        if node is not None and self.is_interface and self.check_is_array(node):
-            assert node.array_dimensions is not None
+        if node is not None and self.is_interface and self.is_master_array(node):
             fanin: dict[str, str] = {}
-            # Generate array index string [i0][i1]... for the intermediate signal
-            array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))
+            # Index the intermediate signal by every open dim (ancestors' + own)
+            array_idx = self.open_dim_index(node)
             fanin["cpuif_wr_ack"] = f"{self.exp.ds.master_port_name(node)}_fanin_ready{array_idx}"
             fanin["cpuif_wr_err"] = f"{self.exp.ds.master_port_name(node)}_fanin_err{array_idx}"
 
@@ -127,11 +126,10 @@ class APB3Cpuif(APB3CpuifFlat):
 
     def fanin_rd(self, node: AddressableNode | None = None, *, error: bool = False) -> str:
         fanin_rd = super().fanin_rd(node, error=error)
-        if node is not None and self.is_interface and self.check_is_array(node):
-            assert node.array_dimensions is not None
+        if node is not None and self.is_interface and self.is_master_array(node):
             fanin: dict[str, str] = {}
-            # Generate array index string [i0][i1]... for the intermediate signal
-            array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))
+            # Index the intermediate signal by every open dim (ancestors' + own)
+            array_idx = self.open_dim_index(node)
             fanin["cpuif_rd_ack"] = f"{self.exp.ds.master_port_name(node)}_fanin_ready{array_idx}"
             fanin["cpuif_rd_err"] = f"{self.exp.ds.master_port_name(node)}_fanin_err{array_idx}"
             fanin["cpuif_rd_data"] = f"{self.exp.ds.master_port_name(node)}_fanin_data{array_idx}"

--- a/src/peakrdl_busdecoder/cpuif/apb4/apb4_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/apb4/apb4_cpuif.py
@@ -116,11 +116,10 @@ class APB4Cpuif(APB4CpuifFlat):
 
     def fanin_wr(self, node: AddressableNode | None = None, *, error: bool = False) -> str:
         fanin_wr = super().fanin_wr(node, error=error)
-        if node is not None and self.is_interface and self.check_is_array(node):
-            assert node.array_dimensions is not None
+        if node is not None and self.is_interface and self.is_master_array(node):
             fanin: dict[str, str] = {}
-            # Generate array index string [i0][i1]... for the intermediate signal
-            array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))
+            # Index the intermediate signal by every open dim (ancestors' + own)
+            array_idx = self.open_dim_index(node)
             fanin["cpuif_wr_ack"] = f"{self.exp.ds.master_port_name(node)}_fanin_ready{array_idx}"
             fanin["cpuif_wr_err"] = f"{self.exp.ds.master_port_name(node)}_fanin_err{array_idx}"
 
@@ -129,11 +128,10 @@ class APB4Cpuif(APB4CpuifFlat):
 
     def fanin_rd(self, node: AddressableNode | None = None, *, error: bool = False) -> str:
         fanin_rd = super().fanin_rd(node, error=error)
-        if node is not None and self.is_interface and self.check_is_array(node):
-            assert node.array_dimensions is not None
+        if node is not None and self.is_interface and self.is_master_array(node):
             fanin: dict[str, str] = {}
-            # Generate array index string [i0][i1]... for the intermediate signal
-            array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))
+            # Index the intermediate signal by every open dim (ancestors' + own)
+            array_idx = self.open_dim_index(node)
             fanin["cpuif_rd_ack"] = f"{self.exp.ds.master_port_name(node)}_fanin_ready{array_idx}"
             fanin["cpuif_rd_err"] = f"{self.exp.ds.master_port_name(node)}_fanin_err{array_idx}"
             fanin["cpuif_rd_data"] = f"{self.exp.ds.master_port_name(node)}_fanin_data{array_idx}"

--- a/src/peakrdl_busdecoder/cpuif/axi4lite/axi4_lite_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/axi4lite/axi4_lite_cpuif.py
@@ -128,11 +128,10 @@ class AXI4LiteCpuif(AXI4LiteCpuifFlat):
 
     def fanin_wr(self, node: AddressableNode | None = None, *, error: bool = False) -> str:
         fanin_wr = super().fanin_wr(node, error=error)
-        if node is not None and self.is_interface and self.check_is_array(node):
-            assert node.array_dimensions is not None
+        if node is not None and self.is_interface and self.is_master_array(node):
             fanin: dict[str, str] = {}
-            # Generate array index string [i0][i1]... for the intermediate signal
-            array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))
+            # Index the intermediate signal by every open dim (ancestors' + own)
+            array_idx = self.open_dim_index(node)
             fanin["cpuif_wr_ack"] = f"{self.exp.ds.master_port_name(node)}_fanin_wr_valid{array_idx}"
             fanin["cpuif_wr_err"] = f"{self.exp.ds.master_port_name(node)}_fanin_wr_err{array_idx}"
 
@@ -142,11 +141,10 @@ class AXI4LiteCpuif(AXI4LiteCpuifFlat):
 
     def fanin_rd(self, node: AddressableNode | None = None, *, error: bool = False) -> str:
         fanin_rd = super().fanin_rd(node, error=error)
-        if node is not None and self.is_interface and self.check_is_array(node):
-            assert node.array_dimensions is not None
+        if node is not None and self.is_interface and self.is_master_array(node):
             fanin: dict[str, str] = {}
-            # Generate array index string [i0][i1]... for the intermediate signal
-            array_idx = "".join(f"[i{i}]" for i in range(len(node.array_dimensions)))
+            # Index the intermediate signal by every open dim (ancestors' + own)
+            array_idx = self.open_dim_index(node)
             fanin["cpuif_rd_ack"] = f"{self.exp.ds.master_port_name(node)}_fanin_ready{array_idx}"
             fanin["cpuif_rd_err"] = f"{self.exp.ds.master_port_name(node)}_fanin_err{array_idx}"
             fanin["cpuif_rd_data"] = f"{self.exp.ds.master_port_name(node)}_fanin_data{array_idx}"
@@ -168,10 +166,11 @@ class AXI4LiteCpuif(AXI4LiteCpuifFlat):
         ]
 
     def fanin_intermediate_declarations(self, node: AddressableNode) -> list[str]:
-        if not node.array_dimensions:
+        dims = self.master_array_dims(node)
+        if not dims:
             return []
 
-        array_str = "".join(f"[{dim}]" for dim in node.array_dimensions)
+        array_str = "".join(f"[{dim}]" for dim in dims)
         return [
             f"logic {self.exp.ds.master_port_name(node)}_fanin_wr_valid{array_str};",
             f"logic {self.exp.ds.master_port_name(node)}_fanin_wr_err{array_str};",

--- a/src/peakrdl_busdecoder/cpuif/base_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/base_cpuif.py
@@ -1,5 +1,6 @@
 import inspect
 import os
+import re
 from collections import deque
 from typing import TYPE_CHECKING
 
@@ -115,6 +116,34 @@ class BaseCpuif:
         if self.unroll and hasattr(node, "current_idx") and node.current_idx is not None:
             return False
         return node.is_array
+
+    def is_master_array(self, node: AddressableNode) -> bool:
+        """Whether a boundary node exposes an *array* of master interfaces.
+
+        Unlike :meth:`check_is_array` (which only looks at the node's own
+        dimensions), this accounts for rolled array *ancestors*: a scalar
+        register under ``bar[3]`` is still a 3-element interface array. Unrolled
+        elements are always scalar.
+        """
+        if self.unroll and getattr(node, "current_idx", None) is not None:
+            return False
+        return bool(self.exp.ds.open_array_dims(node))
+
+    def master_array_dims(self, node: AddressableNode) -> list[int]:
+        """Full open array dimensions (ancestors' + own) for a master port."""
+        if self.unroll and getattr(node, "current_idx", None) is not None:
+            return []
+        return self.exp.ds.open_array_dims(node)
+
+    def open_dim_index(self, node: AddressableNode, indexer: str = "i") -> str:
+        """Bracket index string over every open dim, e.g. ``[i0][i1]``.
+
+        Numbers are positional from the top node, matching the loop variables
+        allocated by the fanin/fanout generators (see
+        ``BusDecoderListener.loop_base_index``).
+        """
+        indexed = get_indexed_path(self.exp.ds.top_node, node, indexer, skip_kw_filter=True)
+        return "".join(re.findall(r"\[[^\]]*\]", indexed))
 
     @staticmethod
     def node_base_address(node: AddressableNode) -> int:

--- a/src/peakrdl_busdecoder/cpuif/fanin_gen.py
+++ b/src/peakrdl_busdecoder/cpuif/fanin_gen.py
@@ -32,11 +32,12 @@ class FaninGenerator(BusDecoderListener):
 
         if self.is_rolled_array(node):
             assert node.array_dimensions is not None
-            for i, dim in enumerate(node.array_dimensions):
+            base = self.loop_base_index(node)
+            for i, dim in enumerate(node.array_dimensions, base):
                 fb = ForLoopBody(
                     "int",
                     f"i{i}",
-                    self._ds.resolve_loop_bound(node, i, dim),
+                    self._ds.resolve_loop_bound(node, i - base, dim),
                 )
                 self._stack.append(fb)
 

--- a/src/peakrdl_busdecoder/cpuif/fanin_intermediate_gen.py
+++ b/src/peakrdl_busdecoder/cpuif/fanin_intermediate_gen.py
@@ -6,6 +6,7 @@ signals that copy from interface arrays using generate loops, which can then
 be safely accessed with variable indices in the fanin logic.
 """
 
+import re
 from collections import deque
 from typing import TYPE_CHECKING
 
@@ -22,7 +23,14 @@ if TYPE_CHECKING:
 
 
 class FaninIntermediateGenerator(BusDecoderListener):
-    """Generates intermediate signals for interface array fanin."""
+    """Generates intermediate signals for interface array fanin.
+
+    Declarations and assignments are emitted per *decode boundary* node, sized
+    and indexed by every open array dimension (rolled array ancestors' + the
+    node's own). Generate loops are opened for every rolled array node on the
+    path (ancestors included) so a boundary below array ancestors is copied
+    element-by-element with constant (genvar) indices.
+    """
 
     walk_unrolled = True
 
@@ -37,30 +45,30 @@ class FaninIntermediateGenerator(BusDecoderListener):
         action = super().enter_AddressableComponent(node)
         should_generate = action == WalkerAction.SkipDescendants
 
-        # Only generate intermediates for rolled interface arrays. Unrolled
-        # elements are individual scalar interfaces that the fanin logic can
-        # reference directly.
-        # Check if cpuif has is_interface attribute (some implementations don't)
+        # Only interface-style cpuifs need intermediate copies. For flat cpuifs
+        # the fanin logic references the unpacked master arrays directly.
         is_interface = getattr(self._cpuif, "is_interface", False)
-        if not is_interface or not self.is_rolled_array(node):
+        if not is_interface:
             return action
 
-        # Generate intermediate signal declarations
-        self._generate_intermediate_declarations(node)
-
-        # Generate assignment logic using generate loops
-        if node.array_dimensions:
-            s_len = len(self._stack)
-            for i, dim in enumerate(node.array_dimensions, s_len - 1):
+        # Open a generate loop for every rolled array dimension on the path so
+        # ancestor dims are covered too. Numbering is positional (single source
+        # of truth) so it lines up with get_indexed_path from the top node.
+        if self.is_rolled_array(node):
+            assert node.array_dimensions is not None
+            base = self.loop_base_index(node)
+            for i, dim in enumerate(node.array_dimensions, base):
                 fb = ForLoopBody(
                     "genvar",
                     f"gi{i}",
-                    self._ds.resolve_loop_bound(node, i - (s_len - 1), dim),
+                    self._ds.resolve_loop_bound(node, i - base, dim),
                 )
                 self._stack.append(fb)
 
-        if should_generate:
-            # Generate assignments from interface array to intermediates
+        # Declarations/assignments belong to the decode boundary only, and only
+        # when it is an interface array (by its own or an ancestor's dims).
+        if should_generate and self._cpuif.is_master_array(node):
+            self._generate_intermediate_declarations(node)
             self._stack[-1] += self._generate_intermediate_assignments(node)
 
         return action
@@ -77,60 +85,49 @@ class FaninIntermediateGenerator(BusDecoderListener):
 
         super().exit_AddressableComponent(node)
 
-    def _generate_intermediate_declarations(self, node: AddressableNode) -> None:
-        """Generate intermediate signal declarations for a node."""
-        inst_name = self._ds.master_port_name(node)
+    def _open_dim_brackets(self, node: AddressableNode, indexer: str) -> str:
+        """Bracket string covering all open dims, e.g. ``[gi0][gi1]``."""
+        indexed = get_indexed_path(self._ds.top_node, node, indexer, skip_kw_filter=True)
+        return "".join(re.findall(r"\[[^\]]*\]", indexed))
 
-        # Array dimensions should be checked before calling this function
-        if not node.array_dimensions:
+    def _generate_intermediate_declarations(self, node: AddressableNode) -> None:
+        """Generate intermediate signal declarations for a boundary node."""
+        name = self._ds.master_port_name(node)
+        dims = self._cpuif.master_array_dims(node)
+        if not dims:
             return
 
-        # Calculate total array size
-        array_size = 1
-        for dim in node.array_dimensions:
-            array_size *= dim
+        array_str = "".join(f"[{dim}]" for dim in dims)
 
-        # Create array dimension string
-        array_str = "".join(f"[{dim}]" for dim in node.array_dimensions)
+        # Signals read back in fanin (APB3/4: PREADY, PSLVERR, PRDATA).
+        self._declarations.append(f"logic {name}_fanin_ready{array_str};")
+        self._declarations.append(f"logic {name}_fanin_err{array_str};")
+        self._declarations.append(f"logic [{self._cpuif.data_width - 1}:0] {name}_fanin_data{array_str};")
 
-        # Generate declarations for each fanin signal
-        # For APB3/4: PREADY, PSLVERR, PRDATA
-        # These are the signals read in fanin
-        self._declarations.append(f"logic {inst_name}_fanin_ready{array_str};")
-        self._declarations.append(f"logic {inst_name}_fanin_err{array_str};")
-        self._declarations.append(
-            f"logic [{self._cpuif.data_width - 1}:0] {inst_name}_fanin_data{array_str};"
-        )
-
-        # Allow CPU interface to add extra intermediate declarations (e.g., write responses)
+        # Allow the cpuif to add extra intermediate declarations (e.g. AXI write
+        # response channel), sized by all open dims.
         self._declarations.extend(self._cpuif.fanin_intermediate_declarations(node))
 
     def _generate_intermediate_assignments(self, node: AddressableNode) -> str:
-        """Generate assignments from interface array to intermediate signals."""
-        inst_name = self._ds.master_port_name(node)
-        # Master interface reference: (possibly path-qualified) port base name
-        # plus the index expressions from the node's own path
-        raw_path = get_indexed_path(node.parent, node, "gi", skip_kw_filter=True)
-        indexed_path = inst_name + raw_path[len(node.inst_name) :]
+        """Generate assignments from the interface array to the intermediates."""
+        name = self._ds.master_port_name(node)
+        dims = self._cpuif.master_array_dims(node)
+        if not dims:
+            return ""
 
-        # Get master prefix - use getattr to avoid type errors
         interface = getattr(self._cpuif, "_interface", None)
         if interface is None:
             return ""
         master_prefix = interface.get_master_prefix()
 
-        # Array dimensions should be checked before calling this function
-        if not node.array_dimensions:
-            return ""
+        # Same bracket string on both sides: the intermediate net and the master
+        # interface element are indexed by every open dimension.
+        brackets = self._open_dim_brackets(node, "gi")
+        indexed_path = name + brackets
 
-        # Create indexed signal names for left-hand side
-        array_idx = "".join(f"[gi{i}]" for i in range(len(node.array_dimensions)))
-
-        # Delegate to cpuif to get the appropriate assignments for this interface type
         assignments = self._cpuif.fanin_intermediate_assignments(
-            node, inst_name, array_idx, master_prefix, indexed_path
+            node, name, brackets, master_prefix, indexed_path
         )
-
         return "\n".join(assignments)
 
     def get_declarations(self) -> str:
@@ -144,11 +141,9 @@ class FaninIntermediateGenerator(BusDecoderListener):
         if not self._declarations:
             return ""
 
-        # Output declarations first
         output = "\n".join(self._declarations)
         output += "\n\n"
 
-        # Then output assignments
         body_str = "\n".join(map(str, self._stack))
         if body_str and body_str.strip():
             output += body_str

--- a/src/peakrdl_busdecoder/cpuif/fanout_gen.py
+++ b/src/peakrdl_busdecoder/cpuif/fanout_gen.py
@@ -29,12 +29,12 @@ class FanoutGenerator(BusDecoderListener):
 
         if self.is_rolled_array(node):
             assert node.array_dimensions is not None
-            s_len = len(self._stack)
-            for i, dim in enumerate(node.array_dimensions, s_len - 1):
+            base = self.loop_base_index(node)
+            for i, dim in enumerate(node.array_dimensions, base):
                 fb = ForLoopBody(
                     "genvar",
                     f"gi{i}",
-                    self._ds.resolve_loop_bound(node, i - (s_len - 1), dim),
+                    self._ds.resolve_loop_bound(node, i - base, dim),
                 )
                 self._stack.append(fb)
 

--- a/src/peakrdl_busdecoder/cpuif/interface.py
+++ b/src/peakrdl_busdecoder/cpuif/interface.py
@@ -12,6 +12,18 @@ if TYPE_CHECKING:
     from .base_cpuif import BaseCpuif
 
 
+def _open_dim_brackets(top_node: AddressableNode, node: AddressableNode, indexer: str) -> str:
+    """Bracket-index string covering every open array dimension of ``node``.
+
+    Walks the path from the top node so rolled array *ancestors* contribute
+    their brackets too (e.g. ``blk[gi0].myreg[gi1]`` -> ``[gi0][gi1]``). The
+    loop-variable numbers match those allocated positionally from the open-dim
+    stride stack (see ``BusDecoderListener.loop_base_index``).
+    """
+    indexed = get_indexed_path(top_node, node, indexer, skip_kw_filter=True)
+    return "".join(re.findall(r"\[[^\]]*\]", indexed))
+
+
 class Interface(ABC):
     """Abstract base class for interface signal handling."""
 
@@ -90,10 +102,12 @@ class SVInterface(Interface):
             if child.current_idx is not None:
                 base = f"{base}_{'_'.join(map(str, child.current_idx))}"
 
-            # Only add array dimensions if this should be treated as an array
-            if self.cpuif.check_is_array(child):
-                assert child.array_dimensions is not None
-                base = f"{base} {''.join(f'[{dim}]' for dim in child.array_dimensions)}"
+            # Size the interface array by *all* open dimensions (rolled array
+            # ancestors' + the node's own), so a boundary under array ancestors
+            # gets one interface per element.
+            dims = self.cpuif.master_array_dims(child)
+            if dims:
+                base = f"{base} {''.join(f'[{dim}]' for dim in dims)}"
 
             master_ports.append(base)
 
@@ -120,16 +134,16 @@ class SVInterface(Interface):
         master_prefix = self.get_master_prefix()
         base = self.master_base_name(node)
 
-        if not self.cpuif.check_is_array(node) and node.current_idx is not None:
+        if not self.cpuif.is_master_array(node) and node.current_idx is not None:
             # A specific element of an unrolled array: the master port is a
             # scalar interface named with an index suffix (e.g. m_apb_blk_0)
             return f"{master_prefix}{base}_{'_'.join(map(str, node.current_idx))}.{signal}"
 
-        # get_indexed_path relative to the parent yields the node's own name
-        # plus any index expressions; substitute the (possibly qualified) base
-        indexed = get_indexed_path(node.parent, node, indexer, skip_kw_filter=True)
-        suffix = indexed[len(node.inst_name) :]
-        return f"{master_prefix}{base}{suffix}.{signal}"
+        # Index by *all* open dimensions: walk from the top node so ancestor
+        # array brackets (e.g. blk[gi0]) are included, then keep only the
+        # bracket expressions to append after the (possibly qualified) base.
+        brackets = _open_dim_brackets(self.cpuif.exp.ds.top_node, node, indexer)
+        return f"{master_prefix}{base}{brackets}.{signal}"
 
     @abstractmethod
     def get_interface_type(self) -> str:
@@ -180,24 +194,23 @@ class FlatInterface(Interface):
         master_prefix = self.get_master_prefix()
         base = f"{master_prefix}{self.master_base_name(node)}"
 
-        if not self.cpuif.check_is_array(node):
+        if not self.cpuif.is_master_array(node):
             # Not an array or an unrolled element
             if node.current_idx is not None:
                 # This is a specific instance of an unrolled array
                 return f"{base}_{signal}_{'_'.join(map(str, node.current_idx))}"
             return f"{base}_{signal}"
 
-        # Is an array
+        # Is an array (possibly by virtue of rolled array ancestors)
         if indexer is not None:
             if isinstance(indexer, str):
-                indexed_path = get_indexed_path(node.parent, node, indexer, skip_kw_filter=True)
-                pattern = r"\[.*?\]"
-                indexes = re.findall(pattern, indexed_path)
-
-                return f"{base}_{signal}{''.join(indexes)}"
+                brackets = _open_dim_brackets(self.cpuif.exp.ds.top_node, node, indexer)
+                return f"{base}_{signal}{brackets}"
 
             return f"{base}_{signal}[{indexer}]"
-        return f"{base}_{signal}[N_{self.master_base_name(node).upper()}S]"
+        # No indexer: this is a declaration -- size by every open dimension.
+        dims = self.cpuif.master_array_dims(node)
+        return f"{base}_{signal}" + "".join(f"[{dim}]" for dim in dims)
 
     @abstractmethod
     def _get_slave_port_declarations(self, slave_prefix: str) -> list[str]:

--- a/src/peakrdl_busdecoder/decode_logic_gen.py
+++ b/src/peakrdl_busdecoder/decode_logic_gen.py
@@ -104,12 +104,12 @@ class DecodeLogicGenerator(BusDecoderListener):
         if node.array_dimensions:
             # arrayed component with new if-body
             self._cond_stack.append(condition)
-            ds_len = len(self._decode_stack)
-            for i, dim in enumerate(node.array_dimensions, ds_len - 1):
+            base = self.loop_base_index(node)
+            for i, dim in enumerate(node.array_dimensions, base):
                 fb = ForLoopBody(
                     "int",
                     f"i{i}",
-                    self._ds.resolve_loop_bound(node, i - (ds_len - 1), dim),
+                    self._ds.resolve_loop_bound(node, i - base, dim),
                 )
                 self._decode_stack.append(fb)
 

--- a/src/peakrdl_busdecoder/design_scanner.py
+++ b/src/peakrdl_busdecoder/design_scanner.py
@@ -43,15 +43,19 @@ class DesignScanner(RDLListener):
         array_strides: tuple[int, ...] | None
         if node.array_dimensions:
             assert node.array_stride is not None, "Array stride should be defined for arrayed components"
-            # Stored innermost-first: [stride, stride*dim_last, stride*dim_last*dim_prev, ...].
-            # Listener replays as append(strides[0]) then appendleft for the rest, matching
-            # the original nested-stride bookkeeping exactly.
+            # Stored outermost-first: one stride per dimension, in the same
+            # order as ``node.array_dimensions`` (outer dim first, inner dim
+            # last). The listener extends the open-dim stride stack with these,
+            # so loop variable ``i{k}`` (allocated positionally from the stack)
+            # always pairs with ``array_stride_stack[k]`` and with the k-th
+            # bracket ``get_indexed_path`` emits when walking from the top node.
             strides_list: list[int] = [node.array_stride]
             current = node.array_stride
             for dim in node.array_dimensions[-1:0:-1]:
                 current = current * dim
                 strides_list.append(current)
-            array_strides = tuple(strides_list)
+            # strides_list is innermost-first; reverse to outermost-first.
+            array_strides = tuple(reversed(strides_list))
         else:
             array_strides = None
 

--- a/src/peakrdl_busdecoder/design_state.py
+++ b/src/peakrdl_busdecoder/design_state.py
@@ -69,6 +69,7 @@ class DesignState:
         # by default, path-qualified when siblings elsewhere in the hierarchy
         # would otherwise collide on the same port name.
         self._master_port_names = self._compute_master_port_names()
+        self._struct_type_names = self._compute_struct_type_names()
 
         if self.cpuif_data_width == 0:
             # Scanner did not find any registers in the design being exported,
@@ -164,6 +165,66 @@ class DesignState:
         Falls back to the instance name for nodes outside the boundary map.
         """
         return self._master_port_names.get(self._normalized_path(node), node.inst_name)
+
+    def _compute_struct_type_names(self) -> dict[str, str]:
+        """Assign a unique SystemVerilog type name to every nested select-struct.
+
+        The select struct nests one ``cpuif_sel_<inst>_t`` typedef per internal
+        (non-boundary) addressable node on the path to the decode boundaries.
+        Two such nodes under different parents can share an instance name (e.g.
+        ``group_a.bar`` and ``group_b.bar``), which would emit duplicate
+        typedefs. As with master port names, colliding members are qualified
+        with their top-relative path so each generated typedef is unique.
+        """
+        # Nodes that emit a nested struct: the internal ancestors (excluding the
+        # top node) of every decode boundary. The struct is always rolled, so
+        # boundaries are computed rolled too.
+        emitters: dict[str, AddressableNode] = {}
+        for boundary in self.get_addressable_children_at_depth(unroll=False):
+            parent = boundary.parent
+            while isinstance(parent, AddressableNode) and parent is not self.top_node:
+                emitters[self._normalized_path(parent)] = parent
+                parent = parent.parent
+
+        groups: dict[str, dict[str, AddressableNode]] = defaultdict(dict)
+        for key, node in emitters.items():
+            groups[node.inst_name][key] = node
+
+        names: dict[str, str] = {}
+        for inst_name, nodes in groups.items():
+            if len(nodes) == 1:
+                names[next(iter(nodes))] = f"cpuif_sel_{inst_name}_t"
+            else:
+                for key, node in nodes.items():
+                    rel_path = node.get_rel_path(self.top_node, empty_array_suffix="")
+                    qualified = re.sub(r"\[[^\]]*\]", "", rel_path).replace(".", "_")
+                    names[key] = f"cpuif_sel_{qualified}_t"
+        return names
+
+    def struct_type_name(self, node: AddressableNode) -> str:
+        """SystemVerilog type name for a node's nested select struct."""
+        return self._struct_type_names.get(self._normalized_path(node), f"cpuif_sel_{node.inst_name}_t")
+
+    def open_array_dims(self, node: AddressableNode) -> list[int]:
+        """All rolled array dimensions open along the path from top down to
+        ``node`` inclusive, outermost-first.
+
+        A boundary node that sits below rolled array ancestors is really an
+        array of interfaces sized by *every* open dimension (ancestors' + its
+        own), not just its own. For repro ``blk[2].myreg[3]`` this returns
+        ``[2, 3]``; for a scalar ``reg_a`` under ``bar[3]`` it returns ``[3]``.
+
+        Unrolled elements (``current_idx`` set) contribute no dimension, so a
+        fully unrolled path yields ``[]`` (a scalar master).
+        """
+        dims: list[int] = []
+        current: AddressableNode | None = node
+        while current is not None and current is not self.top_node:
+            if current.array_dimensions and current.current_idx is None:
+                dims = list(current.array_dimensions) + dims
+            parent = current.parent
+            current = parent if isinstance(parent, AddressableNode) else None
+        return dims
 
     def node_meta(self, node: AddressableNode) -> NodeMeta:
         path = node.get_path()

--- a/src/peakrdl_busdecoder/exporter.py
+++ b/src/peakrdl_busdecoder/exporter.py
@@ -99,7 +99,7 @@ class BusDecoderExporter:
         else:
             top_node = node
 
-        self.ds = DesignState(top_node, kwargs)  # ty: ignore
+        self.ds = DesignState(top_node, kwargs)
 
         cpuif_cls: type[BaseCpuif] = kwargs.pop("cpuif_cls", None) or APB4Cpuif
 

--- a/src/peakrdl_busdecoder/listener.py
+++ b/src/peakrdl_busdecoder/listener.py
@@ -21,6 +21,20 @@ class BusDecoderListener(RDLListener):
         """True for an arrayed node visited rolled-up (not an unrolled element)."""
         return bool(node.array_dimensions) and node.current_idx is None
 
+    def loop_base_index(self, node: AddressableNode) -> int:
+        """First loop-variable number for this node's own array dimensions.
+
+        Single source of truth for ``i{k}`` / ``gi{k}`` numbering. The open-dim
+        stride stack holds exactly one entry per currently-open loop dimension
+        (ancestors' dims first, then this node's dims, outermost-first), so this
+        must be called *after* the base ``enter_AddressableComponent`` pushed
+        this node's own dims. The result is the count of enclosing ancestor loop
+        dimensions -- which is also the index where this node's brackets begin
+        in ``get_indexed_path(top_node, node)``.
+        """
+        own = len(node.array_dimensions) if node.array_dimensions else 0
+        return len(self._array_stride_stack) - own
+
     def should_skip_node(self, node: AddressableNode) -> bool:
         """Check if this node should be skipped (not decoded)."""
         # Check if current depth exceeds max depth
@@ -47,10 +61,10 @@ class BusDecoderListener(RDLListener):
     def enter_AddressableComponent(self, node: AddressableNode) -> WalkerAction | None:
         meta = self._ds.node_meta(node)
         if meta.array_strides is not None and self.is_rolled_array(node):
-            strides = meta.array_strides
-            self._array_stride_stack.append(strides[0])
-            for stride in strides[1:]:
-                self._array_stride_stack.appendleft(stride)
+            # Strides are stored outermost-first; append in order so the stack
+            # stays outer-to-inner across the whole open path (see
+            # loop_base_index).
+            self._array_stride_stack.extend(meta.array_strides)
 
         self._depth += 1
 

--- a/src/peakrdl_busdecoder/struct_gen.py
+++ b/src/peakrdl_busdecoder/struct_gen.py
@@ -27,8 +27,8 @@ class StructGenerator(BusDecoderListener):
 
         # Only create nested struct if we're not skipping and node has addressable children
         if self._ds.node_meta(node).has_addressable_children and not skip:
-            # Push new body onto stack
-            body = StructBody(f"cpuif_sel_{node.inst_name}_t", True, False)
+            # Push new body onto stack (type name disambiguated across siblings)
+            body = StructBody(self._ds.struct_type_name(node), True, False)
             self._stack.append(body)
             self._created_struct_stack.append(True)
         else:

--- a/tests/integration/test_nested_array_boundary.py
+++ b/tests/integration/test_nested_array_boundary.py
@@ -1,0 +1,286 @@
+"""Cross-generator tests for decode boundaries under rolled array ancestors.
+
+Regression coverage for issues #56 and #57. When a decode boundary sits *below*
+one or more rolled array ancestors, every generator stage must agree that the
+boundary is an interface array sized by *all* open dimensions (ancestors' + its
+own), and the loop-variable numbering (``i{k}`` / ``gi{k}``) must line up with
+the stride order the address decoder uses.
+
+- #56: loop-variable naming collisions and dropped ancestor dimensions
+  (``blk[2].myreg[3]``) produced shadowed/undeclared loop indices, scalar
+  ports for arrayed masters, and mis-sized fanin intermediates.
+- #57: two rolled arrays with the same instance name under different parents
+  (``group_a.bar[3]`` / ``group_b.bar[5]``) emitted duplicate module-scope
+  identifiers (both the fanin intermediates and the select-struct typedefs).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+
+import pytest
+from systemrdl.messages import RDLCompileError
+from systemrdl.node import AddressableNode, AddrmapNode, RegNode
+
+from peakrdl_busdecoder.cpuif.apb4 import APB4Cpuif, APB4CpuifFlat
+from peakrdl_busdecoder.cpuif.axi4lite import AXI4LiteCpuif
+
+from .conftest import ExportedDesign
+from .helpers import (
+    parse_decode_assigns,
+    parse_fanout_masters,
+    parse_flat_master_ports,
+    parse_interface_master_ports,
+    parse_sel_struct_leaves,
+    route,
+)
+
+# repro 1 (#56): a 1D array of registers under a 1D array of blocks.
+NESTED_1D_RDL = """
+addrmap top {
+    addrmap outer_t {
+        reg {regwidth=32; field {sw=rw; hw=r;} f;} myreg[3];
+    } blk[2];
+};
+"""
+
+# repro 2 (#57): same-named rolled arrays under sibling parents.
+SIBLING_BAR_RDL = """
+addrmap inner_a { reg {regwidth=32; field {sw=rw; hw=r;} f;} reg_a; };
+addrmap inner_b { reg {regwidth=32; field {sw=rw; hw=r;} f;} reg_b; };
+addrmap top {
+    addrmap {
+        reg {regwidth=32; field {sw=rw; hw=r;} f;} keep_internal;
+        external inner_a bar[3];
+    } group_a;
+    addrmap {
+        reg {regwidth=32; field {sw=rw; hw=r;} f;} keep_internal;
+        external inner_b bar[5];
+    } group_b;
+};
+"""
+
+# 2D array of registers under a 1D array of blocks: pins the loop-number ->
+# stride mapping for a boundary whose open dims interleave with an ancestor.
+NESTED_1D_2D_RDL = """
+addrmap top {
+    addrmap outer2_t {
+        reg {regwidth=32; field {sw=rw; hw=r;} f;} r2[2][3];
+    } blk1[2];
+};
+"""
+
+
+def _full_decode_expectations(top: AddrmapNode) -> list[tuple[int, str]]:
+    """``(relative_address, decode_target)`` for every register, full decode.
+
+    With ``max_decode_depth=0`` each register is its own decode boundary, so the
+    expected select target is the register's full hierarchical path with
+    concrete array indices, e.g. ``blk[0].myreg[1]`` -- exactly the form
+    :func:`helpers.route` resolves loop indices to.
+    """
+    expectations: list[tuple[int, str]] = []
+
+    def visit(node: AddressableNode) -> None:
+        for child in node.children(unroll=True):
+            if not isinstance(child, AddressableNode):
+                continue
+            if isinstance(child, RegNode):
+                segments: list[str] = []
+                walk: AddressableNode = child
+                while walk is not top:
+                    seg = walk.inst_name
+                    for idx in walk.current_idx or []:
+                        seg += f"[{idx}]"
+                    segments.append(seg)
+                    parent = walk.parent
+                    assert isinstance(parent, AddressableNode)
+                    walk = parent
+                target = ".".join(reversed(segments))
+                expectations.append((child.absolute_address - top.absolute_address, target))
+            else:
+                visit(child)
+
+    visit(top)
+    return expectations
+
+
+def _module_logic_declarations(module_text: str) -> list[str]:
+    """Identifier names of every module-scope ``logic ...;`` declaration.
+
+    Only the module body is considered (after the port list closes), and
+    ``typedef struct { ... }`` blocks are removed first so struct *fields*
+    (which live in their own scope and may legitimately repeat across structs)
+    are not counted. The identifier is the token immediately preceding the
+    first array dimension or the terminating semicolon.
+    """
+    body = module_text[module_text.index(");") + 2 :]
+    body = re.sub(r"typedef struct \{.*?\}\s*\w+;", "", body, flags=re.DOTALL)
+    names: list[str] = []
+    for m in re.finditer(r"^\s*logic\s+(?:\[[^\]]*\]\s*)?(?P<name>\w+)", body, re.MULTILINE):
+        names.append(m.group("name"))
+    return names
+
+
+class TestNested1DArrayBoundary:
+    """repro 1 (#56): ``blk[2].myreg[3]`` decoded at full depth."""
+
+    def test_every_register_routes_to_its_own_boundary(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(NESTED_1D_RDL, top="top", max_decode_depth=0)
+        expectations = _full_decode_expectations(design.top)
+        assert len(expectations) == 2 * 3
+
+        for flavor in ("wr", "rd"):
+            assigns = parse_decode_assigns(design.module_text, flavor)
+            for addr, target in expectations:
+                assert route(assigns, addr) == [target], (
+                    f"[{flavor}] address {addr:#x} should select {target}"
+                )
+            # A gap past the last register selects nothing but the error branch.
+            assert route(assigns, 2 * 3 * 4) == ["cpuif_err"]
+
+    def test_ports_intermediates_and_struct_carry_all_open_dims(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(NESTED_1D_RDL, top="top", max_decode_depth=0)
+
+        # Port, select-struct leaf, and fanout all agree the boundary is 2x3.
+        assert parse_interface_master_ports(design.module_text) == {"myreg": (2, 3)}
+        assert parse_sel_struct_leaves(design.module_text) == {"blk.myreg": (2, 3)}
+        assert parse_fanout_masters(design.module_text) == {"myreg"}
+
+        # Fanin intermediates are declared exactly once, for the boundary only,
+        # and sized by both open dimensions. No stray ancestor (``blk_*``) nets.
+        decls = _module_logic_declarations(design.module_text)
+        assert decls.count("myreg_fanin_ready") == 1
+        assert not any(name.startswith("blk_fanin") for name in decls)
+        assert "logic myreg_fanin_ready[2][3];" in design.module_text
+        assert re.search(r"logic \[\d+:0\] myreg_fanin_data\[2\]\[3\];", design.module_text)
+
+    def test_loop_indices_are_unique_and_declared(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        """#56 core symptom: inner loops shadowed / referenced undeclared vars."""
+        design = export_design(NESTED_1D_RDL, top="top", max_decode_depth=0)
+        # The fanin block used to emit `for i0 { for i0 { ... myreg[i1] } }`.
+        assert "for (int i0 = 0; i0 < 2; i0++)" in design.module_text
+        assert "for (int i1 = 0; i1 < 3; i1++)" in design.module_text
+        # The old buggy decoder declared i2 but referenced i1.
+        assert "i2" not in design.module_text
+
+    @pytest.mark.parametrize(
+        ("cpuif_cls", "select_signal"),
+        [(APB4CpuifFlat, "PSEL")],
+    )
+    def test_flat_ports_carry_all_open_dims(
+        self,
+        export_design: Callable[..., ExportedDesign],
+        cpuif_cls: type,
+        select_signal: str,
+    ) -> None:
+        design = export_design(NESTED_1D_RDL, top="top", max_decode_depth=0, cpuif_cls=cpuif_cls)
+        assert parse_flat_master_ports(design.module_text, select_signal) == {"myreg": (2, 3)}
+
+    @pytest.mark.parametrize("cpuif_cls", [APB4Cpuif, AXI4LiteCpuif])
+    def test_routing_is_cpuif_independent(
+        self,
+        export_design: Callable[..., ExportedDesign],
+        cpuif_cls: type,
+    ) -> None:
+        design = export_design(NESTED_1D_RDL, top="top", max_decode_depth=0, cpuif_cls=cpuif_cls)
+        assigns = parse_decode_assigns(design.module_text, "wr")
+        for addr, target in _full_decode_expectations(design.top):
+            assert route(assigns, addr) == [target]
+
+
+class TestNested1D2DCounterMapping:
+    """A 2D register array under a 1D block array pins loop-number/stride order."""
+
+    def test_every_element_routes_by_all_three_indices(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(NESTED_1D_2D_RDL, top="top", max_decode_depth=0)
+        expectations = _full_decode_expectations(design.top)
+        assert len(expectations) == 2 * 2 * 3
+
+        assigns = parse_decode_assigns(design.module_text, "wr")
+        for addr, target in expectations:
+            assert route(assigns, addr) == [target], f"address {addr:#x} should select {target}"
+
+    def test_ports_and_struct_carry_three_dims(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(NESTED_1D_2D_RDL, top="top", max_decode_depth=0)
+        assert parse_interface_master_ports(design.module_text) == {"r2": (2, 2, 3)}
+        assert parse_sel_struct_leaves(design.module_text) == {"blk1.r2": (2, 2, 3)}
+        # Three distinct, sequentially-numbered loop indices.
+        for var in ("i0", "i1", "i2"):
+            assert f"for (int {var} = 0;" in design.module_text
+
+
+class TestSiblingSameNameArrays:
+    """repro 2 (#57): ``group_a.bar[3]`` and ``group_b.bar[5]``."""
+
+    @pytest.mark.parametrize("cpuif_cls", [APB4Cpuif, AXI4LiteCpuif])
+    def test_no_module_scope_identifier_declared_twice(
+        self,
+        export_design: Callable[..., ExportedDesign],
+        cpuif_cls: type,
+    ) -> None:
+        design = export_design(SIBLING_BAR_RDL, top="top", max_decode_depth=0, cpuif_cls=cpuif_cls)
+
+        decls = _module_logic_declarations(design.module_text)
+        duplicates = {name for name in decls if decls.count(name) > 1}
+        assert not duplicates, f"duplicate module-scope logic declarations: {duplicates}"
+
+        # The pre-fix bug: one `bar_fanin_ready[3]` and one `bar_fanin_ready[5]`.
+        assert "bar_fanin_ready" not in decls
+
+        # Select-struct typedefs must also be unique (no duplicate
+        # `cpuif_sel_bar_t`).
+        typedef_names = re.findall(r"\}\s*(cpuif_sel_\w+_t);", design.module_text)
+        assert len(typedef_names) == len(set(typedef_names)), (
+            f"duplicate select-struct typedefs: {typedef_names}"
+        )
+
+    def test_boundary_ports_are_per_register_and_sized_by_bar(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(SIBLING_BAR_RDL, top="top", max_decode_depth=0)
+        ports = parse_interface_master_ports(design.module_text)
+        assert ports == {
+            "group_a_keep_internal": (),
+            "reg_a": (3,),
+            "group_b_keep_internal": (),
+            "reg_b": (5,),
+        }
+        # Per-boundary intermediates, sized by the enclosing bar dimension.
+        assert "logic reg_a_fanin_ready[3];" in design.module_text
+        assert "logic reg_b_fanin_ready[5];" in design.module_text
+
+    def test_fanout_and_fanin_agree_with_ports(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        design = export_design(SIBLING_BAR_RDL, top="top", max_decode_depth=0)
+        ports = set(parse_interface_master_ports(design.module_text))
+        assert parse_fanout_masters(design.module_text) == ports
+
+
+class TestUnrollNestedArrayBoundary:
+    """``cpuif_unroll`` unrolls each array element into a scalar master port.
+
+    Under a rolled-array *ancestor* the unrolled leaf names collide (every
+    ``blk[k].myreg[j]`` reduces to ``myreg_j``), so this combination cannot be
+    expressed with unique scalar ports. Rather than emit broken SystemVerilog,
+    the design validator rejects it up front. Rolled mode (the default) is the
+    supported way to decode below a rolled array ancestor and is covered above.
+    """
+
+    def test_unroll_below_array_ancestor_is_rejected(
+        self, export_design: Callable[..., ExportedDesign]
+    ) -> None:
+        with pytest.raises(RDLCompileError):
+            export_design(NESTED_1D_RDL, top="top", max_decode_depth=0, cpuif_unroll=True)


### PR DESCRIPTION
# Description of change

Fixes #56. Fixes #57.

Both issues are symptoms of one hole: a decode boundary that sits **below** a rolled array ancestor produced broken SystemVerilog — inconsistent loop-variable numbering across generators (shadowed `i0`s, references to undeclared `i1`), scalar ports for registers that exist N times, and module-scope fanin intermediates declared per rolled-array node with colliding names/sizes.

**Loop numbering** now has a single source of truth in `BusDecoderListener`: the stride stack holds one entry per open loop dimension, contiguous and outermost-first (scanner now stores strides in that order), and `loop_base_index(node)` hands every generator its starting `i{k}`/`gi{k}`. Position *k* in the stack ↔ the *k*-th bracket of the node's indexed path ↔ the *k*-th stride term in the address predicate, so the decoder arithmetic, sel-struct paths, loop declarations, ports, and intermediates all agree.

**Ports/fanout/fanin under array ancestors** now carry all open dims: for `blk[2]` containing `myreg[3]` at `max_decode_depth=0`, the port is `m_apb_myreg [2][3]` and fanout/fanin index `cpuif_*_sel.blk[gi0].myreg[gi1]` ↔ `m_apb_myreg[gi0][gi1]`. Fanin intermediates are declared per **boundary** node (not per rolled array node), sized by all open dims, and named via the path-qualified master port name — the #57 repro's duplicate `bar_fanin_ready[3]`/`bar_fanin_ready[5]` becomes `reg_a_fanin_ready[3]`/`reg_b_fanin_ready[5]`. Colliding nested-struct typedef names get the same path-qualification treatment (`cpuif_sel_group_a_bar_t`).

Both issue repros now pass `verilator --lint-only` with 0 errors in APB4 interface, APB4 flat, and AXI4-Lite interface styles.

Deliberate scope cut: `cpuif_unroll=True` below a rolled array ancestor is rejected by the existing validator (unrolled leaf names genuinely collide) rather than made to work; a test pins the rejection. Existing 1D unroll behavior is unchanged.

Note: includes the same one-line `exporter.py` typecheck fix as #70 (main's typecheck CI is currently red); it deduplicates on merge.

# Checklist

- [x] I have reviewed this project's [contribution guidelines](https://github.com/arnavsacheti/PeakRDL-BusDecoder/blob/main/CONTRIBUTING.md)
- [x] This change has been tested and does not break any of the existing unit tests. (260 passed, 1 skipped locally; verified independently in a clean worktree. Cocotb sims need CI's verilator container.)
- [x] If this change adds new features, I have added new unit tests that cover them. (13 new tests in `tests/integration/test_nested_array_boundary.py`: RDL-derived routing checks through the decode evaluator, port/sel/fanout/intermediate consistency, no-duplicate-identifier regression, and a 1D-ancestor + 2D-child counter-mapping case.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMFtybV4NhYwyMKNwVLkGn

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMFtybV4NhYwyMKNwVLkGn)_