### PR TITLE
feat(cpuif): add --clk-src {cpuif,design} flag

### DIFF
--- a/src/peakrdl_busdecoder/__peakrdl__.py
+++ b/src/peakrdl_busdecoder/__peakrdl__.py
@@ -124,6 +124,19 @@ class Exporter(ExporterSubcommandPlugin):
         )
 
         arg_group.add_argument(
+            "--clk-src",
+            choices=("cpuif", "design"),
+            default="design",
+            help="""Select where the bus decoder gets its clock and reset.
+            'cpuif' bundles clk/reset with the CPU interface (slave carries
+            PCLK/PRESETn or ACLK/ARESETn, fanned out to each master).
+            'design' (default) drops clk/reset from the CPU interface and
+            exposes top-level 'clk'/'rst' ports — the design distributes
+            clock/reset to downstream slaves itself.
+            """,
+        )
+
+        arg_group.add_argument(
             "--max-decode-depth",
             type=int,
             default=1,
@@ -148,4 +161,5 @@ class Exporter(ExporterSubcommandPlugin):
             cpuif_unroll=options.unroll,
             parametrize=options.parametrize,
             max_decode_depth=options.max_decode_depth,
+            clk_src=options.clk_src,
         )

--- a/src/peakrdl_busdecoder/cpuif/apb/apb_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/apb/apb_cpuif.py
@@ -43,6 +43,10 @@ class APBCpuifBase(BaseCpuif):
         sel_path = get_indexed_path(self.exp.ds.top_node, node, "gi")
         sel_expr = f"cpuif_wr_sel.{sel_path}|cpuif_rd_sel.{sel_path}"
 
+        if self.clk_src == "cpuif":
+            fanout[self.signal("PCLK", node, "gi")] = self.signal("PCLK")
+            fanout[self.signal("PRESETn", node, "gi")] = self.signal("PRESETn")
+
         fanout[self.signal("PSEL", node, "gi")] = sel_expr
         fanout[self.signal("PENABLE", node, "gi")] = f"({sel_expr}) & {self.signal('PENABLE')}"
         fanout[self.signal("PWRITE", node, "gi")] = f"cpuif_wr_sel.{sel_path}"

--- a/src/peakrdl_busdecoder/cpuif/apb/apb_interface.py
+++ b/src/peakrdl_busdecoder/cpuif/apb/apb_interface.py
@@ -45,9 +45,13 @@ class APBFlatInterface(FlatInterface):
 
     def _get_slave_port_declarations(self, slave_prefix: str) -> list[str]:
         cpuif = self.cpuif
-        ports = [
-            f"input  logic {slave_prefix}PCLK",
-            f"input  logic {slave_prefix}PRESETn",
+        ports: list[str] = []
+        if cpuif.clk_src == "cpuif":
+            ports += [
+                f"input  logic {slave_prefix}PCLK",
+                f"input  logic {slave_prefix}PRESETn",
+            ]
+        ports += [
             f"input  logic {slave_prefix}PSEL",
             f"input  logic {slave_prefix}PENABLE",
             f"input  logic {slave_prefix}PWRITE",
@@ -67,9 +71,13 @@ class APBFlatInterface(FlatInterface):
 
     def _get_master_port_declarations(self, child: AddressableNode, master_prefix: str) -> list[str]:
         cpuif = self.cpuif
-        ports = [
-            f"output logic {self.signal('PCLK', child)}",
-            f"output logic {self.signal('PRESETn', child)}",
+        ports: list[str] = []
+        if cpuif.clk_src == "cpuif":
+            ports += [
+                f"output logic {self.signal('PCLK', child)}",
+                f"output logic {self.signal('PRESETn', child)}",
+            ]
+        ports += [
             f"output logic {self.signal('PSEL', child)}",
             f"output logic {self.signal('PENABLE', child)}",
             f"output logic {self.signal('PWRITE', child)}",

--- a/src/peakrdl_busdecoder/cpuif/axi4lite/axi4_lite_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/axi4lite/axi4_lite_cpuif.py
@@ -52,6 +52,10 @@ class AXI4LiteCpuifFlat(BaseCpuif):
         wr_sel = f"cpuif_wr_sel.{get_indexed_path(self.exp.ds.top_node, node, 'gi')}"
         rd_sel = f"cpuif_rd_sel.{get_indexed_path(self.exp.ds.top_node, node, 'gi')}"
 
+        if self.clk_src == "cpuif":
+            fanout[self.signal("ACLK", node, "gi")] = self.signal("ACLK")
+            fanout[self.signal("ARESETn", node, "gi")] = self.signal("ARESETn")
+
         # Write address channel
         fanout[self.signal("AWVALID", node, "gi")] = wr_sel
         if self._can_truncate_addr(node, array_stack):

--- a/src/peakrdl_busdecoder/cpuif/axi4lite/axi4_lite_interface.py
+++ b/src/peakrdl_busdecoder/cpuif/axi4lite/axi4_lite_interface.py
@@ -29,7 +29,14 @@ class AXI4LiteFlatInterface(FlatInterface):
         return "m_axil_"
 
     def _get_slave_port_declarations(self, slave_prefix: str) -> list[str]:
-        return [
+        ports: list[str] = []
+        if self.cpuif.clk_src == "cpuif":
+            ports += [
+                # Clocking
+                f"input  logic {slave_prefix}ACLK",
+                f"input  logic {slave_prefix}ARESETn",
+            ]
+        ports += [
             # Write address channel
             f"input  logic {slave_prefix}AWVALID",
             f"output logic {slave_prefix}AWREADY",
@@ -55,9 +62,16 @@ class AXI4LiteFlatInterface(FlatInterface):
             f"output logic [{self.cpuif.data_width - 1}:0] {slave_prefix}RDATA",
             f"output logic [1:0] {slave_prefix}RRESP",
         ]
+        return ports
 
     def _get_master_port_declarations(self, child: AddressableNode, master_prefix: str) -> list[str]:
-        return [
+        ports: list[str] = []
+        if self.cpuif.clk_src == "cpuif":
+            ports += [
+                f"output logic {self.signal('ACLK', child)}",
+                f"output logic {self.signal('ARESETn', child)}",
+            ]
+        ports += [
             # Write address channel
             f"output logic {self.signal('AWVALID', child)}",
             f"input  logic {self.signal('AWREADY', child)}",
@@ -83,3 +97,4 @@ class AXI4LiteFlatInterface(FlatInterface):
             f"input  logic [{self.cpuif.data_width - 1}:0] {self.signal('RDATA', child)}",
             f"input  logic [1:0] {self.signal('RRESP', child)}",
         ]
+        return ports

--- a/src/peakrdl_busdecoder/cpuif/base_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/base_cpuif.py
@@ -45,6 +45,7 @@ class BaseCpuif:
         self.exp = exp
         self.reset = exp.ds.top_node.cpuif_reset
         self.unroll = exp.ds.cpuif_unroll
+        self.clk_src = exp.ds.clk_src
 
         interface_cls: type[Interface]
         if self.use_sv_interface:
@@ -97,7 +98,10 @@ class BaseCpuif:
     @property
     def port_declaration(self) -> str:
         slave_name = self.slave_name_sv if self.use_sv_interface else self.slave_name_flat
-        return self._interface.get_port_declaration(slave_name, self.master_signal_prefix)
+        intf_ports = self._interface.get_port_declaration(slave_name, self.master_signal_prefix)
+        if self.clk_src == "design":
+            return ",\n".join(["input  logic clk", "input  logic rst", intf_ports])
+        return intf_ports
 
     def signal(
         self,

--- a/src/peakrdl_busdecoder/design_state.py
+++ b/src/peakrdl_busdecoder/design_state.py
@@ -22,6 +22,7 @@ class DesignStateKwargs(TypedDict, total=False):
     cpuif_unroll: bool
     parametrize: bool
     max_decode_depth: int
+    clk_src: str
 
 
 class DesignState:
@@ -45,6 +46,9 @@ class DesignState:
         self.cpuif_unroll: bool = kwargs.pop("cpuif_unroll", False)
         self.parametrize: bool = kwargs.pop("parametrize", False)
         self.max_decode_depth: int = kwargs.pop("max_decode_depth", 1)
+        self.clk_src: str = kwargs.pop("clk_src", "design")
+        if self.clk_src not in ("cpuif", "design"):
+            msg.fatal(f"clk_src must be 'cpuif' or 'design', got {self.clk_src!r}")
 
         # ------------------------
         # Info about the design

--- a/src/peakrdl_busdecoder/exporter.py
+++ b/src/peakrdl_busdecoder/exporter.py
@@ -29,6 +29,7 @@ class ExporterKwargs(TypedDict, total=False):
     parametrize: bool
     reuse_hwif_typedefs: bool
     max_decode_depth: int
+    clk_src: str
 
 
 if TYPE_CHECKING:
@@ -92,6 +93,16 @@ class BusDecoderExporter:
             components. A value of 0 decodes all levels (infinite depth). A value
             of 1 decodes only top-level children. A value of 2 decodes top-level
             and one level deeper, etc. By default, the decoder descends 1 level deep.
+        clk_src: str
+            Selects where the bus decoder gets its clock and reset.
+
+            - "cpuif": clk/reset are bundled with the CPU interface. The slave
+              bus carries the protocol-defined clock/reset (PCLK/PRESETn for
+              APB, ACLK/ARESETn for AXI4-Lite) and the decoder fans them out
+              to each master interface.
+            - "design" (default): the CPU interface carries no clk/reset. The
+              module exposes top-level ``clk`` and ``rst`` ports; the design
+              is responsible for distributing clock/reset to downstream slaves.
         """
         # If it is the root node, skip to top addrmap
         if isinstance(node, RootNode):

--- a/tests/cocotb_lib/wrapper_gen.py
+++ b/tests/cocotb_lib/wrapper_gen.py
@@ -130,6 +130,7 @@ def generate_verilator_intf_wrapper(
     global_addr_width: int,
     global_data_width: int,
     output_dir: Path,
+    include_top_clk_rst: bool = True,
 ) -> Path:
     """Generate a Verilator wrapper for an interface-based bus decoder module.
 
@@ -148,6 +149,10 @@ def generate_verilator_intf_wrapper(
         Data width of the bus.
     output_dir:
         Directory to write the wrapper file.
+    include_top_clk_rst:
+        Wire top-level ``clk``/``rst`` wrapper inputs through to the DUT.
+        Matches the exporter's default ``clk_src="design"`` mode, where the
+        module has these ports; pass False for ``clk_src="cpuif"`` DUTs.
 
     Returns
     -------
@@ -165,6 +170,11 @@ def generate_verilator_intf_wrapper(
 
     # --- Port declarations ---------------------------------------------------
     ports: list[str] = []
+
+    # Top-level clock/reset (clk_src="design" mode)
+    if include_top_clk_rst:
+        ports.append("    input  logic clk")
+        ports.append("    input  logic rst")
 
     # Slave flat ports
     for sig_name, wk, is_input in signals:
@@ -275,6 +285,9 @@ def generate_verilator_intf_wrapper(
     # --- DUT instantiation ---------------------------------------------------
     lines.append(f"    {module_name} dut (")
     dut_ports: list[str] = []
+    if include_top_clk_rst:
+        dut_ports.append("        .clk(clk)")
+        dut_ports.append("        .rst(rst)")
     dut_ports.append(f"        .{slave_name}({slave_name}_intf)")
     for child in children:
         inst = child["inst_name"]

--- a/tests/unit/test_clk_src.py
+++ b/tests/unit/test_clk_src.py
@@ -1,0 +1,133 @@
+"""Tests for the clk_src exporter option."""
+
+from collections.abc import Callable
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+from systemrdl.node import AddrmapNode
+
+from peakrdl_busdecoder import BusDecoderExporter
+from peakrdl_busdecoder.cpuif import BaseCpuif
+from peakrdl_busdecoder.cpuif.apb3 import APB3Cpuif, APB3CpuifFlat
+from peakrdl_busdecoder.cpuif.apb4 import APB4Cpuif, APB4CpuifFlat
+from peakrdl_busdecoder.cpuif.axi4lite import AXI4LiteCpuif, AXI4LiteCpuifFlat
+
+
+def _export_and_read(top: AddrmapNode, *, cpuif_cls: type[BaseCpuif], **kwargs) -> str:
+    with TemporaryDirectory() as tmpdir:
+        BusDecoderExporter().export(top, tmpdir, cpuif_cls=cpuif_cls, **kwargs)
+        return (Path(tmpdir) / f"{top.inst_name}.sv").read_text()
+
+
+@pytest.fixture
+def simple_top(compile_rdl: Callable[..., AddrmapNode]) -> AddrmapNode:
+    return compile_rdl(
+        """
+        addrmap leaf {
+            reg { field { sw=rw; hw=r; } data[31:0]; } r0 @ 0x0;
+        };
+        addrmap top_t {
+            leaf a @ 0x0;
+            leaf b @ 0x1000;
+        };
+        """,
+        top="top_t",
+    )
+
+
+# ---------------------------------------------------------------------------
+# clk_src=design (default): no bus clk/reset, top-level clk/rst ports added
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cpuif_cls,clk_signal,reset_signal",
+    [
+        (APB3CpuifFlat, "PCLK", "PRESETn"),
+        (APB4CpuifFlat, "PCLK", "PRESETn"),
+        (AXI4LiteCpuifFlat, "ACLK", "ARESETn"),
+    ],
+)
+def test_design_default_drops_bus_clk_reset(
+    simple_top: AddrmapNode, cpuif_cls: type[BaseCpuif], clk_signal: str, reset_signal: str
+) -> None:
+    content = _export_and_read(simple_top, cpuif_cls=cpuif_cls)
+    for prefix in ("s_apb_", "s_axil_", "m_apb_a_", "m_apb_b_", "m_axil_a_", "m_axil_b_"):
+        assert f"{prefix}{clk_signal}" not in content
+        assert f"{prefix}{reset_signal}" not in content
+
+
+@pytest.mark.parametrize(
+    "cpuif_cls", [APB3CpuifFlat, APB4CpuifFlat, AXI4LiteCpuifFlat, APB3Cpuif, APB4Cpuif, AXI4LiteCpuif]
+)
+def test_design_adds_top_level_clk_rst_ports(
+    simple_top: AddrmapNode, cpuif_cls: type[BaseCpuif]
+) -> None:
+    content = _export_and_read(simple_top, cpuif_cls=cpuif_cls)
+    assert "input  logic clk" in content
+    assert "input  logic rst" in content
+
+
+# ---------------------------------------------------------------------------
+# clk_src=cpuif: bus carries protocol clk/reset on slave + master, no top-level
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cpuif_cls,slave_prefix,clk,rst",
+    [
+        (APB3CpuifFlat, "s_apb_", "PCLK", "PRESETn"),
+        (APB4CpuifFlat, "s_apb_", "PCLK", "PRESETn"),
+        (AXI4LiteCpuifFlat, "s_axil_", "ACLK", "ARESETn"),
+    ],
+)
+def test_if_adds_bus_clk_reset_on_slave(
+    simple_top: AddrmapNode,
+    cpuif_cls: type[BaseCpuif],
+    slave_prefix: str,
+    clk: str,
+    rst: str,
+) -> None:
+    content = _export_and_read(simple_top, cpuif_cls=cpuif_cls, clk_src="cpuif")
+    assert f"{slave_prefix}{clk}" in content
+    assert f"{slave_prefix}{rst}" in content
+
+
+@pytest.mark.parametrize(
+    "cpuif_cls,master_prefix,clk,rst",
+    [
+        (APB3CpuifFlat, "m_apb_a_", "PCLK", "PRESETn"),
+        (APB4CpuifFlat, "m_apb_a_", "PCLK", "PRESETn"),
+        (AXI4LiteCpuifFlat, "m_axil_a_", "ACLK", "ARESETn"),
+    ],
+)
+def test_if_drives_master_clk_reset_in_fanout(
+    simple_top: AddrmapNode,
+    cpuif_cls: type[BaseCpuif],
+    master_prefix: str,
+    clk: str,
+    rst: str,
+) -> None:
+    content = _export_and_read(simple_top, cpuif_cls=cpuif_cls, clk_src="cpuif")
+    assert f"{master_prefix}{clk}" in content
+    assert f"{master_prefix}{rst}" in content
+    # And fanout assignment exists
+    assert f"assign {master_prefix}{clk}" in content
+
+
+@pytest.mark.parametrize(
+    "cpuif_cls", [APB3CpuifFlat, APB4CpuifFlat, AXI4LiteCpuifFlat, APB3Cpuif, APB4Cpuif, AXI4LiteCpuif]
+)
+def test_if_omits_top_level_clk_rst_ports(
+    simple_top: AddrmapNode, cpuif_cls: type[BaseCpuif]
+) -> None:
+    content = _export_and_read(simple_top, cpuif_cls=cpuif_cls, clk_src="cpuif")
+    # Top-level "input logic clk," should not appear (note: protocol-named PCLK/ACLK
+    # are fine; we look for the bare "clk" / "rst" port lines).
+    assert "input  logic clk" not in content
+    assert "input  logic rst" not in content
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+def test_invalid_clk_src_rejected(simple_top: AddrmapNode) -> None:
+    with pytest.raises(Exception):  # systemrdl raises a fatal compile error
+        _export_and_read(simple_top, cpuif_cls=APB4Cpuif, clk_src="bogus")


### PR DESCRIPTION
Replaces #67, which was auto-closed when its stacked base branch (`refactor/cpuif-simplify`, PR #66) was merged and deleted. Same commit, rebased onto main.

## Summary

New exporter kwarg / CLI flag `--clk-src {cpuif,design}` (default `design`) that selects where the bus decoder gets its clock and reset.

| Mode | Slave bus | Master bus | Top-level module ports |
|---|---|---|---|
| `cpuif` | carries PCLK/PRESETn (or ACLK/ARESETn) | carries PCLK/PRESETn (or ACLK/ARESETn), driven from slave in fanout | none added |
| `design` (default) | no clk/reset on bus | no clk/reset on bus | adds `input logic clk, input logic rst` |

In `design` mode the bus decoder is purely a signal fanout for non-clock signals; the design distributes clock/reset to downstream slaves itself. This is also the foundation for upcoming pipelining support (the module owns its own clock domain).

Renamed/branched off the stale draft in #32. Differences from that draft:
- Replaces the boolean `omit_intf_clk_reset` flag with a `clk_src` selector that scales as more modes are added.
- Targets the merged APB3/APB4 cpuif (per #66).
- Uses the declarative interface layer — no per-protocol duplication.
- Drops the unrelated `assert_wr_sel` removal that the original PR bundled in.

## Test plan
- [x] `pytest -m "not simulation and not verilator"` — 282 passed, 1 skipped (rebased onto main after #64/#66 landed)
- [x] `tests/unit/test_clk_src.py` covers default-design (no bus clk/reset, top-level clk/rst ports), `clk_src=cpuif` (slave + master clk/reset, fanout assigns), validation rejection, and SV-interface variants for APB3 / APB4 / AXI4-Lite
- [ ] cocotb smoke (APB3 / APB4 / AXI4-Lite) in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMyMaHGbpgrU6YvFVTjKYW