### PR TITLE
fix: remove unused ty suppression that fails typecheck CI

### DIFF
--- a/src/peakrdl_busdecoder/rdl_params.py
+++ b/src/peakrdl_busdecoder/rdl_params.py
@@ -124,7 +124,7 @@ class RdlParameterExtractor:
         try:
             yield
         finally:
-            ParameterRef.get_value = original  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+            ParameterRef.get_value = original  # type: ignore[assignment]
 
     def reevaluate_node(self, node: Node) -> None:
         """Clear & re-evaluate any Parameters defined on ``node``.


### PR DESCRIPTION
One-line fix: main's typecheck CI is red after #64 merged — its green CI run predated ty's stricter unused-suppression check (same failure mode #70 fixed). Removes the now-unused `ty: ignore[invalid-assignment]` on the restore-side assignment in `RdlParameterExtractor.trace()`; the install-side directive on line 123 is still exercised and kept.

Verified with CI's exact invocation (`uv sync --extra cli && uvx ty check src/`): All checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMyMaHGbpgrU6YvFVTjKYW