### PR TITLE
feat: make APB downstream signal gating opt-in via --gate-signals

### DIFF
--- a/src/peakrdl_busdecoder/__peakrdl__.py
+++ b/src/peakrdl_busdecoder/__peakrdl__.py
@@ -147,6 +147,17 @@ class Exporter(ExporterSubcommandPlugin):
             """,
         )
 
+        arg_group.add_argument(
+            "--gate-signals",
+            action="store_true",
+            default=False,
+            help="""Gate downstream broadcast signals with the per-slave select.
+            For APB this drives PENABLE/PADDR/PWDATA/PSTRB/PPROT to '0 on
+            unselected masters (APB protocol-correct). When omitted, broadcast
+            signals fan out unmodified.
+            """,
+        )
+
     def do_export(self, top_node: AddrmapNode, options: argparse.Namespace) -> None:
         cpuifs = self.get_cpuifs()
 
@@ -162,4 +173,5 @@ class Exporter(ExporterSubcommandPlugin):
             parametrize=options.parametrize,
             max_decode_depth=options.max_decode_depth,
             clk_src=options.clk_src,
+            gate_signals=options.gate_signals,
         )

--- a/src/peakrdl_busdecoder/cpuif/apb/apb_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/apb/apb_cpuif.py
@@ -37,6 +37,7 @@ class APBCpuifBase(BaseCpuif):
 
     def fanout(self, node: AddressableNode, array_stack: deque[int]) -> str:
         fanout: dict[str, str] = {}
+        gate = self.exp.ds.gate_signals
 
         addr_width = self.addr_width_param(node)
 
@@ -48,7 +49,9 @@ class APBCpuifBase(BaseCpuif):
             fanout[self.signal("PRESETn", node, "gi")] = self.signal("PRESETn")
 
         fanout[self.signal("PSEL", node, "gi")] = sel_expr
-        fanout[self.signal("PENABLE", node, "gi")] = f"({sel_expr}) & {self.signal('PENABLE')}"
+        fanout[self.signal("PENABLE", node, "gi")] = (
+            f"({sel_expr}) & {self.signal('PENABLE')}" if gate else self.signal("PENABLE")
+        )
         fanout[self.signal("PWRITE", node, "gi")] = f"cpuif_wr_sel.{sel_path}"
 
         if self._can_truncate_addr(node, array_stack):
@@ -59,13 +62,19 @@ class APBCpuifBase(BaseCpuif):
             for i, stride in enumerate(array_stack):
                 addr_comp.append(f"{self.addr_width}'(gi{i}*{SVInt(stride, self.addr_width)})")
             addr_value = f"{addr_width}'({' - '.join(addr_comp)})"
-        fanout[self.signal("PADDR", node, "gi")] = f"({sel_expr}) ? {addr_value} : '0"
+        fanout[self.signal("PADDR", node, "gi")] = f"({sel_expr}) ? {addr_value} : '0" if gate else addr_value
 
         if self.has_pprot:
-            fanout[self.signal("PPROT", node, "gi")] = f"({sel_expr}) ? {self.signal('PPROT')} : '0"
-        fanout[self.signal("PWDATA", node, "gi")] = f"({sel_expr}) ? cpuif_wr_data : '0"
+            fanout[self.signal("PPROT", node, "gi")] = (
+                f"({sel_expr}) ? {self.signal('PPROT')} : '0" if gate else self.signal("PPROT")
+            )
+        fanout[self.signal("PWDATA", node, "gi")] = (
+            f"({sel_expr}) ? cpuif_wr_data : '0" if gate else "cpuif_wr_data"
+        )
         if self.has_pstrb:
-            fanout[self.signal("PSTRB", node, "gi")] = f"({sel_expr}) ? cpuif_wr_byte_en : '0"
+            fanout[self.signal("PSTRB", node, "gi")] = (
+                f"({sel_expr}) ? cpuif_wr_byte_en : '0" if gate else "cpuif_wr_byte_en"
+            )
 
         return "\n".join(f"assign {lhs} = {rhs};" for lhs, rhs in fanout.items())
 

--- a/src/peakrdl_busdecoder/design_state.py
+++ b/src/peakrdl_busdecoder/design_state.py
@@ -23,6 +23,7 @@ class DesignStateKwargs(TypedDict, total=False):
     parametrize: bool
     max_decode_depth: int
     clk_src: str
+    gate_signals: bool
 
 
 class DesignState:
@@ -49,6 +50,7 @@ class DesignState:
         self.clk_src: str = kwargs.pop("clk_src", "design")
         if self.clk_src not in ("cpuif", "design"):
             msg.fatal(f"clk_src must be 'cpuif' or 'design', got {self.clk_src!r}")
+        self.gate_signals: bool = kwargs.pop("gate_signals", False)
 
         # ------------------------
         # Info about the design

--- a/src/peakrdl_busdecoder/exporter.py
+++ b/src/peakrdl_busdecoder/exporter.py
@@ -30,6 +30,7 @@ class ExporterKwargs(TypedDict, total=False):
     reuse_hwif_typedefs: bool
     max_decode_depth: int
     clk_src: str
+    gate_signals: bool
 
 
 if TYPE_CHECKING:
@@ -103,6 +104,11 @@ class BusDecoderExporter:
             - "design" (default): the CPU interface carries no clk/reset. The
               module exposes top-level ``clk`` and ``rst`` ports; the design
               is responsible for distributing clock/reset to downstream slaves.
+        gate_signals: bool
+            Gate downstream broadcast signals with the per-slave select. For APB
+            this drives PENABLE/PADDR/PWDATA/PSTRB/PPROT to '0 on unselected
+            masters. By default, broadcast signals fan out unmodified, keeping
+            the master-to-slave datapath free of the extra gating mux.
         """
         # If it is the root node, skip to top addrmap
         if isinstance(node, RootNode):

--- a/tests/cocotb/apb3/smoke/test_runner.py
+++ b/tests/cocotb/apb3/smoke/test_runner.py
@@ -33,6 +33,7 @@ def test_apb3_smoke(tmp_path: Path, rdl_file: str, top_name: str) -> None:
         build_root,
         cpuif_cls=APB3CpuifFlat,
         control_signal="PSEL",
+        exporter_kwargs={"gate_signals": True},
     )
 
     sources = get_verilog_sources(

--- a/tests/cocotb/apb3/smoke/test_runner_intf.py
+++ b/tests/cocotb/apb3/smoke/test_runner_intf.py
@@ -35,6 +35,7 @@ def test_apb3_intf_smoke(tmp_path: Path, rdl_file: str, top_name: str) -> None:
         build_root,
         cpuif_cls=APB3Cpuif,
         control_signal="PSEL",
+        exporter_kwargs={"gate_signals": True},
     )
 
     # Generate Verilator wrapper (Verilator can't have SV interface ports at top level)

--- a/tests/cocotb/apb4/smoke/test_runner.py
+++ b/tests/cocotb/apb4/smoke/test_runner.py
@@ -36,6 +36,7 @@ def test_apb4_smoke(tmp_path: Path, rdl_file: str, top_name: str) -> None:
         build_root,
         cpuif_cls=APB4CpuifFlat,
         control_signal="PSEL",
+        exporter_kwargs={"gate_signals": True},
     )
 
     sources = get_verilog_sources(

--- a/tests/cocotb/apb4/smoke/test_runner_intf.py
+++ b/tests/cocotb/apb4/smoke/test_runner_intf.py
@@ -35,6 +35,7 @@ def test_apb4_intf_smoke(tmp_path: Path, rdl_file: str, top_name: str) -> None:
         build_root,
         cpuif_cls=APB4Cpuif,
         control_signal="PSEL",
+        exporter_kwargs={"gate_signals": True},
     )
 
     # Generate Verilator wrapper (Verilator can't have SV interface ports at top level)

--- a/tests/unit/test_gate_signals.py
+++ b/tests/unit/test_gate_signals.py
@@ -1,0 +1,72 @@
+"""Tests for the --gate-signals / gate_signals=True opt-in feature."""
+
+from collections.abc import Callable
+from pathlib import Path
+
+from systemrdl.node import AddrmapNode
+
+from peakrdl_busdecoder import BusDecoderExporter
+from peakrdl_busdecoder.cpuif.apb3 import APB3CpuifFlat
+from peakrdl_busdecoder.cpuif.apb4 import APB4CpuifFlat
+
+
+_RDL = """
+addrmap multi_slave {
+    reg { field { sw=rw; hw=r; } data[31:0]; } a @ 0x0;
+    reg { field { sw=rw; hw=r; } data[31:0]; } b @ 0x4;
+};
+"""
+
+
+def test_apb4_default_does_not_gate(
+    compile_rdl: Callable[..., AddrmapNode], tmp_path: Path
+) -> None:
+    top = compile_rdl(_RDL, top="multi_slave")
+    BusDecoderExporter().export(top, str(tmp_path), cpuif_cls=APB4CpuifFlat)
+    sv = (tmp_path / "multi_slave.sv").read_text()
+    # PENABLE/PADDR/PWDATA/PSTRB/PPROT must fan out unmodified
+    assert "= s_apb_PENABLE;" in sv
+    assert "= cpuif_wr_data;" in sv
+    assert "= s_apb_PSTRB;" in sv
+    assert "= s_apb_PPROT;" in sv
+    # No gating expression on broadcast signals
+    assert "& s_apb_PENABLE" not in sv
+    assert "? cpuif_wr_data : '0" not in sv
+
+
+def test_apb4_gate_signals_emits_gating(
+    compile_rdl: Callable[..., AddrmapNode], tmp_path: Path
+) -> None:
+    top = compile_rdl(_RDL, top="multi_slave")
+    BusDecoderExporter().export(
+        top, str(tmp_path), cpuif_cls=APB4CpuifFlat, gate_signals=True
+    )
+    sv = (tmp_path / "multi_slave.sv").read_text()
+    assert "& s_apb_PENABLE" in sv
+    assert "? cpuif_wr_data : '0" in sv
+    assert "? s_apb_PPROT : '0" in sv
+    assert "? cpuif_wr_byte_en : '0" in sv
+
+
+def test_apb3_default_does_not_gate(
+    compile_rdl: Callable[..., AddrmapNode], tmp_path: Path
+) -> None:
+    top = compile_rdl(_RDL, top="multi_slave")
+    BusDecoderExporter().export(top, str(tmp_path), cpuif_cls=APB3CpuifFlat)
+    sv = (tmp_path / "multi_slave.sv").read_text()
+    assert "= s_apb_PENABLE;" in sv
+    assert "= cpuif_wr_data;" in sv
+    assert "& s_apb_PENABLE" not in sv
+    assert "? cpuif_wr_data : '0" not in sv
+
+
+def test_apb3_gate_signals_emits_gating(
+    compile_rdl: Callable[..., AddrmapNode], tmp_path: Path
+) -> None:
+    top = compile_rdl(_RDL, top="multi_slave")
+    BusDecoderExporter().export(
+        top, str(tmp_path), cpuif_cls=APB3CpuifFlat, gate_signals=True
+    )
+    sv = (tmp_path / "multi_slave.sv").read_text()
+    assert "& s_apb_PENABLE" in sv
+    assert "? cpuif_wr_data : '0" in sv


### PR DESCRIPTION
Supersedes #65, ported onto the merged `cpuif/apb/` package from #66 (the original branch targeted the pre-refactor `apb3/`/`apb4/` cpuif files).

## Summary

Adds a `--gate-signals` CLI flag (and `gate_signals=True` exporter kwarg) that toggles per-slave gating of APB broadcast signals (`PENABLE`, `PADDR`, `PWDATA`, `PSTRB`, `PPROT`).

- **Default off.** Broadcast signals fan out unmodified — fewer logic stages on the master→slave datapath.
- **`--gate-signals` on.** Each broadcast signal is masked by the slave's select expression: `(sel) ? signal : '0` (and `(sel) & PENABLE`).

## Rationale

The gating mux adds an extra LUT stage on the longest combinational path from CPU master input to slave input — a real timing cost on tight `PCLK` designs. The previous default forced every consumer to absorb that stage; making it opt-in keeps the timing-friendly path as the default.

Per the AMBA APB spec, well-behaved slaves only sample these signals when their `PSEL` is asserted, so toggling them while `PSEL=0` is benign. Gating is useful for lower switching activity on quiet sub-blocks (power/EMI), cleaner debug waveforms, and defending against non-conformant slaves that latch inputs without checking `PSEL`.

`PSEL` is always per-slave and unaffected. `PWRITE` is already driven per-slave from `cpuif_wr_sel.X` and is also unaffected.

## Test plan
- [x] Full local suite including cocotb/Verilator: 376 passed, 1 skipped (4 new tests in `tests/unit/test_gate_signals.py` cover both modes for APB3 and APB4)
- [x] Register-access smoke runners (which assert `PENABLE == 0` on unselected masters) opt into gating via `exporter_kwargs={"gate_signals": True}`; stress and variable-depth runners exercise the default ungated path
- [x] ruff check / ruff format / `uvx ty check src/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMyMaHGbpgrU6YvFVTjKYW