### PR TITLE
feat(cpuif): add --apb-buffer for APB slave-side I/O register slice

### DIFF
--- a/src/peakrdl_busdecoder/__peakrdl__.py
+++ b/src/peakrdl_busdecoder/__peakrdl__.py
@@ -124,6 +124,18 @@ class Exporter(ExporterSubcommandPlugin):
         )
 
         arg_group.add_argument(
+            "--apb-buffer",
+            choices=("none", "in", "out", "both"),
+            default="none",
+            help="""Insert a single-flop register slice on the APB slave-side
+            I/O. 'in' buffers slave-side inputs (PSEL/PENABLE/PWRITE/PADDR/
+            PWDATA/PSTRB/PPROT), 'out' buffers slave-side outputs (PRDATA/
+            PREADY/PSLVERR), 'both' buffers both, 'none' (default) disables.
+            Only applies to APB cpuifs; requires --clk-src=design.
+            """,
+        )
+
+        arg_group.add_argument(
             "--clk-src",
             choices=("cpuif", "design"),
             default="design",
@@ -174,4 +186,5 @@ class Exporter(ExporterSubcommandPlugin):
             max_decode_depth=options.max_decode_depth,
             clk_src=options.clk_src,
             gate_signals=options.gate_signals,
+            apb_buffer=options.apb_buffer,
         )

--- a/src/peakrdl_busdecoder/cpuif/apb/apb_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/apb/apb_cpuif.py
@@ -8,6 +8,13 @@ from ...utils import get_indexed_path
 from ..base_cpuif import BaseCpuif
 from .apb_interface import APBFlatInterface, APBSVInterface
 
+# Slave-side input signals that may be buffered. Order is the buffer-block emit order.
+_BUFFERABLE_IN_NAMES: tuple[str, ...] = ("PSEL", "PENABLE", "PWRITE", "PADDR", "PWDATA")
+# Optional input signals: name -> cpuif class attr that gates inclusion.
+_BUFFERABLE_IN_OPTIONAL: dict[str, str] = {"PPROT": "has_pprot", "PSTRB": "has_pstrb"}
+# Slave-side output signals that may be buffered.
+_BUFFERABLE_OUT_NAMES: tuple[str, ...] = ("PRDATA", "PREADY", "PSLVERR")
+
 
 class APBCpuifBase(BaseCpuif):
     """Shared APB3/APB4 cpuif. Variants differ by ``apb_interface_type`` and
@@ -20,10 +27,108 @@ class APBCpuifBase(BaseCpuif):
     slave_name_flat = "s_apb_"
     slave_name_sv = "s_apb"
     master_signal_prefix = "m_apb_"
+    supports_apb_buffer = True
 
     apb_interface_type: ClassVar[str] = ""  # set by concrete subclasses
     has_pprot: ClassVar[bool] = False
     has_pstrb: ClassVar[bool] = False
+
+    # ---- I/O buffer ----
+
+    @property
+    def _apb_buffer(self) -> str:
+        return self.exp.ds.apb_buffer
+
+    @property
+    def buffer_in(self) -> bool:
+        return self._apb_buffer in ("in", "both")
+
+    @property
+    def buffer_out(self) -> bool:
+        return self._apb_buffer in ("out", "both")
+
+    @property
+    def has_apb_buffer(self) -> bool:
+        return self.buffer_in or self.buffer_out
+
+    def _active_buffer_in_names(self) -> list[str]:
+        names = list(_BUFFERABLE_IN_NAMES)
+        for nm, attr in _BUFFERABLE_IN_OPTIONAL.items():
+            if getattr(self, attr):
+                names.append(nm)
+        return names
+
+    def _signal_width_decl(self, name: str) -> str:
+        if name in ("PSEL", "PENABLE", "PWRITE", "PREADY", "PSLVERR"):
+            return ""
+        if name == "PADDR":
+            return f"[{self.addr_width - 1}:0] "
+        if name in ("PWDATA", "PRDATA"):
+            return f"[{self.data_width - 1}:0] "
+        if name == "PSTRB":
+            return f"[{self.data_width // 8 - 1}:0] "
+        if name == "PPROT":
+            return "[2:0] "
+        raise ValueError(f"unknown APB signal {name!r}")
+
+    def signal(
+        self,
+        signal: str,
+        node: AddressableNode | None = None,
+        idx: str | int | None = None,
+    ) -> str:
+        # Slave-side reference (no node) gets redirected to the buffer wire
+        # when buffering is enabled for that direction.
+        if node is None and idx is None:
+            if self.buffer_in and signal in self._active_buffer_in_names():
+                return f"apb_in_{signal}"
+            if self.buffer_out and signal in _BUFFERABLE_OUT_NAMES:
+                return f"apb_out_{signal}"
+        return super().signal(signal, node, idx)
+
+    def apb_buffer_block(self) -> str:
+        """SV snippet that declares apb_in_*/apb_out_* wires and (when enabled)
+        flops them on/off the slave port. Returns empty string when no buffering."""
+        if not self.has_apb_buffer:
+            return ""
+
+        in_names = self._active_buffer_in_names() if self.buffer_in else []
+        out_names = list(_BUFFERABLE_OUT_NAMES) if self.buffer_out else []
+
+        lines: list[str] = []
+        for nm in in_names:
+            lines.append(f"logic {self._signal_width_decl(nm)}apb_in_{nm};")
+        for nm in out_names:
+            lines.append(f"logic {self._signal_width_decl(nm)}apb_out_{nm};")
+
+        if in_names:
+            lines.append("")
+            lines.append("always_ff @(posedge clk or posedge rst) begin")
+            lines.append("    if (rst) begin")
+            for nm in in_names:
+                lines.append(f"        apb_in_{nm} <= '0;")
+            lines.append("    end else begin")
+            for nm in in_names:
+                src = self._interface.signal(nm)
+                lines.append(f"        apb_in_{nm} <= {src};")
+            lines.append("    end")
+            lines.append("end")
+
+        if out_names:
+            lines.append("")
+            lines.append("always_ff @(posedge clk or posedge rst) begin")
+            lines.append("    if (rst) begin")
+            for nm in out_names:
+                sink = self._interface.signal(nm)
+                lines.append(f"        {sink} <= '0;")
+            lines.append("    end else begin")
+            for nm in out_names:
+                sink = self._interface.signal(nm)
+                lines.append(f"        {sink} <= apb_out_{nm};")
+            lines.append("    end")
+            lines.append("end")
+
+        return "\n".join(lines)
 
     sv_array_fanin_wr: ClassVar[list[tuple[str, str, str]]] = [
         ("cpuif_wr_ack", "_fanin_ready", "PREADY"),

--- a/src/peakrdl_busdecoder/cpuif/apb/apb_tmpl.sv
+++ b/src/peakrdl_busdecoder/cpuif/apb/apb_tmpl.sv
@@ -8,6 +8,13 @@
     end
 `endif
 {%- endif %}
+{%- if cpuif.has_apb_buffer %}
+
+//--------------------------------------------------------------------------
+// APB I/O buffer (single-flop register slice)
+//--------------------------------------------------------------------------
+{{cpuif.apb_buffer_block()}}
+{%- endif %}
 
 assign cpuif_req   = {{cpuif.signal("PSEL")}};
 assign cpuif_wr_en = {{cpuif.signal("PWRITE")}};

--- a/src/peakrdl_busdecoder/cpuif/base_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/base_cpuif.py
@@ -28,6 +28,9 @@ class BaseCpuif:
     # Whether this cpuif uses the SystemVerilog `interface` form (vs. flat ports).
     use_sv_interface: ClassVar[bool] = False
 
+    # Whether this cpuif honors the ``apb_buffer`` exporter option.
+    supports_apb_buffer: ClassVar[bool] = False
+
     # Slave/master signal/interface names.
     slave_name_flat: ClassVar[str] = ""  # e.g. "s_apb_"
     slave_name_sv: ClassVar[str] = ""  # e.g. "s_apb"
@@ -46,6 +49,12 @@ class BaseCpuif:
         self.reset = exp.ds.top_node.cpuif_reset
         self.unroll = exp.ds.cpuif_unroll
         self.clk_src = exp.ds.clk_src
+
+        if exp.ds.apb_buffer != "none" and not self.supports_apb_buffer:
+            exp.ds.top_node.env.msg.fatal(
+                f"apb_buffer={exp.ds.apb_buffer!r} is not supported by "
+                f"{type(self).__name__}; only APB cpuifs honor this option."
+            )
 
         interface_cls: type[Interface]
         if self.use_sv_interface:

--- a/src/peakrdl_busdecoder/design_state.py
+++ b/src/peakrdl_busdecoder/design_state.py
@@ -24,6 +24,7 @@ class DesignStateKwargs(TypedDict, total=False):
     max_decode_depth: int
     clk_src: str
     gate_signals: bool
+    apb_buffer: str
 
 
 class DesignState:
@@ -51,6 +52,14 @@ class DesignState:
         if self.clk_src not in ("cpuif", "design"):
             msg.fatal(f"clk_src must be 'cpuif' or 'design', got {self.clk_src!r}")
         self.gate_signals: bool = kwargs.pop("gate_signals", False)
+
+        self.apb_buffer: str = kwargs.pop("apb_buffer", "none")
+        if self.apb_buffer not in ("none", "in", "out", "both"):
+            msg.fatal(
+                f"apb_buffer must be one of 'none', 'in', 'out', 'both', got {self.apb_buffer!r}"
+            )
+        if self.apb_buffer != "none" and self.clk_src != "design":
+            msg.fatal("apb_buffer requires clk_src='design' (the buffer flops use the design clk/rst)")
 
         # ------------------------
         # Info about the design

--- a/src/peakrdl_busdecoder/exporter.py
+++ b/src/peakrdl_busdecoder/exporter.py
@@ -31,6 +31,7 @@ class ExporterKwargs(TypedDict, total=False):
     max_decode_depth: int
     clk_src: str
     gate_signals: bool
+    apb_buffer: str
 
 
 if TYPE_CHECKING:
@@ -109,6 +110,12 @@ class BusDecoderExporter:
             this drives PENABLE/PADDR/PWDATA/PSTRB/PPROT to '0 on unselected
             masters. By default, broadcast signals fan out unmodified, keeping
             the master-to-slave datapath free of the extra gating mux.
+        apb_buffer: str
+            Insert a single-flop register slice on the APB slave-side I/O.
+            One of: "none" (default), "in" (slave-side inputs only), "out"
+            (slave-side outputs only), "both". Only applies to APB cpuifs;
+            requires ``clk_src='design'`` (uses the design clk/rst). APB
+            handshake is preserved via PREADY-stretching.
         """
         # If it is the root node, skip to top addrmap
         if isinstance(node, RootNode):

--- a/tests/unit/test_apb_buffer.py
+++ b/tests/unit/test_apb_buffer.py
@@ -1,0 +1,130 @@
+"""Tests for the apb_buffer exporter option."""
+
+from collections.abc import Callable
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+from systemrdl.node import AddrmapNode
+
+from peakrdl_busdecoder import BusDecoderExporter
+from peakrdl_busdecoder.cpuif import BaseCpuif
+from peakrdl_busdecoder.cpuif.apb3 import APB3Cpuif, APB3CpuifFlat
+from peakrdl_busdecoder.cpuif.apb4 import APB4Cpuif, APB4CpuifFlat
+from peakrdl_busdecoder.cpuif.axi4lite import AXI4LiteCpuif
+
+
+def _export_and_read(top: AddrmapNode, *, cpuif_cls: type[BaseCpuif], **kwargs) -> str:
+    with TemporaryDirectory() as tmpdir:
+        BusDecoderExporter().export(top, tmpdir, cpuif_cls=cpuif_cls, **kwargs)
+        return (Path(tmpdir) / f"{top.inst_name}.sv").read_text()
+
+
+@pytest.fixture
+def simple_top(compile_rdl: Callable[..., AddrmapNode]) -> AddrmapNode:
+    return compile_rdl(
+        """
+        addrmap leaf {
+            reg { field { sw=rw; hw=r; } data[31:0]; } r0 @ 0x0;
+        };
+        addrmap top_t { leaf a @ 0x0; leaf b @ 0x1000; };
+        """,
+        top="top_t",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default: no buffer
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("cpuif_cls", [APB3CpuifFlat, APB4CpuifFlat, APB3Cpuif, APB4Cpuif])
+def test_default_no_buffer_signals(simple_top: AddrmapNode, cpuif_cls: type[BaseCpuif]) -> None:
+    content = _export_and_read(simple_top, cpuif_cls=cpuif_cls)
+    assert "apb_in_" not in content
+    assert "apb_out_" not in content
+    assert "APB I/O buffer" not in content
+
+
+# ---------------------------------------------------------------------------
+# apb_buffer="in"
+# ---------------------------------------------------------------------------
+def test_buffer_in_apb4_flat(simple_top: AddrmapNode) -> None:
+    content = _export_and_read(simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer="in")
+    # Input wire declarations
+    for sig in ("PSEL", "PENABLE", "PWRITE", "PADDR", "PWDATA", "PPROT", "PSTRB"):
+        assert f"apb_in_{sig}" in content
+    # Flop block reads from slave port
+    assert "apb_in_PSEL <= s_apb_PSEL;" in content
+    assert "apb_in_PADDR <= s_apb_PADDR;" in content
+    # Downstream cpuif logic reads buffered signal, not raw port
+    assert "assign cpuif_req   = apb_in_PSEL;" in content
+    assert "assign cpuif_wr_data = apb_in_PWDATA;" in content
+    # Output side untouched: PRDATA assigned directly to slave port
+    assert "assign s_apb_PRDATA = cpuif_rd_data;" in content
+    assert "apb_out_" not in content
+
+
+def test_buffer_in_apb3_omits_pprot_pstrb(simple_top: AddrmapNode) -> None:
+    """APB3 has no PPROT/PSTRB, so the buffer must skip them too."""
+    content = _export_and_read(simple_top, cpuif_cls=APB3CpuifFlat, apb_buffer="in")
+    assert "apb_in_PSEL" in content
+    assert "apb_in_PPROT" not in content
+    assert "apb_in_PSTRB" not in content
+
+
+# ---------------------------------------------------------------------------
+# apb_buffer="out"
+# ---------------------------------------------------------------------------
+def test_buffer_out_apb4_flat(simple_top: AddrmapNode) -> None:
+    content = _export_and_read(simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer="out")
+    # Output wire declarations and flop block write to slave port
+    for sig in ("PRDATA", "PREADY", "PSLVERR"):
+        assert f"apb_out_{sig}" in content
+        assert f"s_apb_{sig} <= apb_out_{sig};" in content
+    # Cpuif logic writes to buffered signal
+    assert "assign apb_out_PRDATA = cpuif_rd_data;" in content
+    # Input side untouched
+    assert "assign cpuif_req   = s_apb_PSEL;" in content
+    assert "apb_in_" not in content
+
+
+# ---------------------------------------------------------------------------
+# apb_buffer="both"
+# ---------------------------------------------------------------------------
+def test_buffer_both_apb4_flat(simple_top: AddrmapNode) -> None:
+    content = _export_and_read(simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer="both")
+    assert "apb_in_PSEL" in content
+    assert "apb_out_PRDATA" in content
+    # Two separate always_ff blocks
+    assert content.count("always_ff @(posedge clk or posedge rst)") >= 2
+
+
+# ---------------------------------------------------------------------------
+# Master fanout untouched by buffer mode
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("apb_buffer", ["none", "in", "out", "both"])
+def test_master_fanout_unchanged(simple_top: AddrmapNode, apb_buffer: str) -> None:
+    content = _export_and_read(simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer=apb_buffer)
+    # Master ports always exist with protocol names regardless of buffer mode
+    assert "m_apb_a_PSEL" in content
+    assert "m_apb_a_PADDR" in content
+    assert "m_apb_a_PRDATA" in content
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+def test_buffer_requires_clk_src_design(simple_top: AddrmapNode) -> None:
+    with pytest.raises(Exception):
+        _export_and_read(
+            simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer="in", clk_src="cpuif"
+        )
+
+
+def test_buffer_rejected_on_non_apb_cpuif(simple_top: AddrmapNode) -> None:
+    with pytest.raises(Exception):
+        _export_and_read(simple_top, cpuif_cls=AXI4LiteCpuif, apb_buffer="in")
+
+
+def test_invalid_apb_buffer_value(simple_top: AddrmapNode) -> None:
+    with pytest.raises(Exception):
+        _export_and_read(simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer="bogus")


### PR DESCRIPTION
Adds an `--apb-buffer` CLI flag / `apb_buffer` exporter kwarg that inserts a single-flop register slice on the APB slave-side I/O. (Branch `feature/apb-io-buffer` on the remote is the stale pre-rebase copy of this same work; this PR is the version rebased onto main after #66/#72/#74 landed.)

## Summary

| Mode | Registered signals |
|---|---|
| `none` (default) | nothing — passthrough |
| `in` | slave-side inputs: PSEL/PENABLE/PWRITE/PADDR/PWDATA/PSTRB/PPROT |
| `out` | slave-side outputs: PRDATA/PREADY/PSLVERR |
| `both` | both directions |

- `APBCpuifBase.signal()` redirects slave-side references to `apb_in_<X>`/`apb_out_<X>` wires when the corresponding direction is buffered; master-side fanout is unchanged.
- `APBCpuifBase.apb_buffer_block()` emits the wire declarations and a single `always_ff` per buffered direction.
- APB handshake is preserved via PREADY-stretching: each buffered direction adds one cycle to the access phase, allowed by the protocol.
- Validation: `apb_buffer != "none"` requires `clk_src='design'` (the flops use the design clk/rst); non-APB cpuifs reject the option via `BaseCpuif.supports_apb_buffer`.

Builds on the top-level `clk`/`rst` ports from #72; foundation for upcoming pipelining support.

## Test plan
- [x] Full local suite including cocotb/Verilator: 391 passed, 1 skipped (15 new tests in `tests/unit/test_apb_buffer.py`)
- [x] ruff check / `uvx ty check src/` clean
- [x] Rebase conflicts with #74's gate-signals plumbing resolved (keep-both in ExporterKwargs/DesignStateKwargs/CLI passthrough)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMyMaHGbpgrU6YvFVTjKYW