### PR TITLE
fix: do not drive clk/reset through SV-interface master modports (clk_src=cpuif)

### DIFF
--- a/src/peakrdl_busdecoder/cpuif/apb/apb_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/apb/apb_cpuif.py
@@ -149,7 +149,10 @@ class APBCpuifBase(BaseCpuif):
         sel_path = get_indexed_path(self.exp.ds.top_node, node, "gi")
         sel_expr = f"cpuif_wr_sel.{sel_path}|cpuif_rd_sel.{sel_path}"
 
-        if self.clk_src == "cpuif":
+        if self.clk_src == "cpuif" and not self.is_interface:
+            # Flat style only: the SV interface's master modport declares
+            # PCLK/PRESETn as inputs, so the decoder cannot drive them; in
+            # interface style the design clocks each interface at instantiation.
             fanout[self.signal("PCLK", node, "gi")] = self.signal("PCLK")
             fanout[self.signal("PRESETn", node, "gi")] = self.signal("PRESETn")
 

--- a/src/peakrdl_busdecoder/cpuif/axi4lite/axi4_lite_cpuif.py
+++ b/src/peakrdl_busdecoder/cpuif/axi4lite/axi4_lite_cpuif.py
@@ -52,7 +52,10 @@ class AXI4LiteCpuifFlat(BaseCpuif):
         wr_sel = f"cpuif_wr_sel.{get_indexed_path(self.exp.ds.top_node, node, 'gi')}"
         rd_sel = f"cpuif_rd_sel.{get_indexed_path(self.exp.ds.top_node, node, 'gi')}"
 
-        if self.clk_src == "cpuif":
+        if self.clk_src == "cpuif" and not self.is_interface:
+            # Flat style only: the SV interface's master modport declares
+            # ACLK/ARESETn as inputs, so the decoder cannot drive them; in
+            # interface style the design clocks each interface at instantiation.
             fanout[self.signal("ACLK", node, "gi")] = self.signal("ACLK")
             fanout[self.signal("ARESETn", node, "gi")] = self.signal("ARESETn")
 

--- a/tests/unit/test_clk_src.py
+++ b/tests/unit/test_clk_src.py
@@ -1,5 +1,6 @@
 """Tests for the clk_src exporter option."""
 
+import re
 from collections.abc import Callable
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -110,6 +111,30 @@ def test_if_drives_master_clk_reset_in_fanout(
     assert f"{master_prefix}{rst}" in content
     # And fanout assignment exists
     assert f"assign {master_prefix}{clk}" in content
+
+
+@pytest.mark.parametrize(
+    "cpuif_cls,clk,rst",
+    [
+        (APB3Cpuif, "PCLK", "PRESETn"),
+        (APB4Cpuif, "PCLK", "PRESETn"),
+        (AXI4LiteCpuif, "ACLK", "ARESETn"),
+    ],
+)
+def test_if_interface_style_never_drives_master_clk_reset(
+    simple_top: AddrmapNode,
+    cpuif_cls: type[BaseCpuif],
+    clk: str,
+    rst: str,
+) -> None:
+    """The SV interface's master modport declares clk/reset as inputs, so the
+    decoder must not fan them out (the design clocks each interface at
+    instantiation). Driving them makes the module fail to elaborate."""
+    content = _export_and_read(simple_top, cpuif_cls=cpuif_cls, clk_src="cpuif")
+    for signal in (clk, rst):
+        assert re.search(rf"assign m_\w+\.{signal}\b", content) is None, (
+            f"interface-style fanout must not drive {signal}"
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description of change

Fixes the latent issue flagged during the #66/#67 rebase (see the comment on #67): with `clk_src=cpuif`, fanout emitted `assign m_apb_X.PCLK = s_apb.PCLK` (and `ACLK`/`ARESETn` for AXI4-Lite), but the `*_intf` **master modports declare clk/reset as `input`**, so every SV-interface-style module exported with `clk_src=cpuif` failed to elaborate (verilator: "can't drive input-only modport", 9 errors per design).

Fix: skip the clk/reset fanout in interface style — the interface bundle already carries the clock and the design connects it when instantiating each interface. Flat style is unchanged (clk/reset remain driven output ports, as the existing `test_if_drives_master_clk_reset_in_fanout` tests pin).

# Checklist

- [x] I have reviewed this project's [contribution guidelines](https://github.com/arnavsacheti/PeakRDL-BusDecoder/blob/main/CONTRIBUTING.md)
- [x] This change has been tested and does not break any of the existing unit tests. (304 passed, 1 skipped locally)
- [x] If this change adds new features, I have added new unit tests that cover them. (new `test_if_interface_style_never_drives_master_clk_reset` for APB3/APB4/AXI4-Lite; verified all three interface cpuifs now pass `verilator --lint-only` with `clk_src=cpuif` — previously 9 errors each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMFtybV4NhYwyMKNwVLkGn

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMFtybV4NhYwyMKNwVLkGn)_