### PR TITLE
docs: document --clk-src, --gate-signals, and --apb-buffer

### DIFF
--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -36,3 +36,13 @@ The following options are available on the ``peakrdl busdecoder`` command:
 * ``--addr-width``: Override the slave address width
 * ``--unroll``: Unroll arrayed children into discrete interfaces
 * ``--max-decode-depth``: Control how far the decoder descends into hierarchy
+* ``--parametrize``: Propagate top-level SystemRDL parameters into the
+  generated module (see :doc:`parameters`)
+* ``--clk-src``: Select where the decoder gets its clock and reset (``design``
+  (default) adds top-level ``clk``/``rst`` ports; ``cpuif`` bundles clock/reset
+  with the CPU interface bus)
+* ``--gate-signals``: Gate APB broadcast signals with each slave's select so
+  unselected slaves see all-zero inputs (off by default)
+* ``--apb-buffer``: Insert a single-flop register slice on the APB slave-side
+  I/O (``none`` (default), ``in``, ``out``, ``both``); requires
+  ``--clk-src design``

--- a/docs/cpuif/apb.rst
+++ b/docs/cpuif/apb.rst
@@ -57,3 +57,38 @@ Flattened inputs/outputs
 
     * Command line: ``--cpuif apb4-flat``
     * Class: :class:`peakrdl_busdecoder.cpuif.apb4.APB4CpuifFlat`
+
+
+Broadcast Signal Gating
+-----------------------
+
+By default, the broadcast signals ``PENABLE``, ``PADDR``, ``PWDATA``,
+``PSTRB``, and ``PPROT`` fan out to every master port unmodified, keeping the
+master-to-slave datapath free of extra logic stages. Per the AMBA APB
+specification, conformant slaves only sample these signals while their
+``PSEL`` is asserted, so this is protocol-safe.
+
+Passing ``--gate-signals`` masks each broadcast signal with the slave's select
+expression, so unselected slaves see all-zero inputs. This costs one extra mux
+stage on the datapath, but reduces switching activity on quiet sub-blocks
+(power/EMI), produces cleaner debug waveforms, and defends against
+non-conformant slaves that latch inputs without checking ``PSEL``. ``PSEL``
+and ``PWRITE`` are always driven per-slave and are unaffected by this option.
+
+
+Slave-Side Register Slice
+-------------------------
+
+``--apb-buffer`` inserts a single-flop register slice on the APB slave-side
+I/O:
+
+* ``none`` (default): no buffering
+* ``in``: registers the slave-side inputs
+  (``PSEL``/``PENABLE``/``PWRITE``/``PADDR``/``PWDATA``/``PSTRB``/``PPROT``)
+* ``out``: registers the slave-side outputs (``PRDATA``/``PREADY``/``PSLVERR``)
+* ``both``: registers both directions
+
+The APB handshake is preserved through ``PREADY``-stretching: each buffered
+direction adds one cycle to the access phase, which the protocol allows. The
+buffer flops use the design clock and reset, so this option requires
+``--clk-src design`` (the default). Non-APB CPU interfaces reject the option.

--- a/docs/cpuif/axi4lite.rst
+++ b/docs/cpuif/axi4lite.rst
@@ -40,7 +40,7 @@ AXI4-Lite Protocol Limitations: Per-Slave Back-Pressure
 The generated decoder does not implement the full AXI4-Lite handshake on
 either side of the bus. It treats every transaction as a single-cycle
 ping-pong between the CPU master and the currently addressed child slave.
-This is tracked as a known limitation in
+This is an intentional, documented limitation; the background is recorded in
 `issue #59 <https://github.com/arnavsacheti/PeakRDL-BusDecoder/issues/59>`_.
 
 CPU-side acceptance is unconditional
@@ -98,5 +98,7 @@ Consequences
       general-purpose AXI4-Lite subordinates or interconnect fabrics.
 
     Full handshake support (respecting downstream ``*READY`` and CPU-side
-    ``BREADY``/``RREADY``) is tracked in
-    `issue #59 <https://github.com/arnavsacheti/PeakRDL-BusDecoder/issues/59>`_.
+    ``BREADY``/``RREADY``) would be a new feature; the rationale for the
+    current single-cycle design is recorded in
+    `issue #59 <https://github.com/arnavsacheti/PeakRDL-BusDecoder/issues/59>`_
+    (closed as documented).

--- a/docs/cpuif/introduction.rst
+++ b/docs/cpuif/introduction.rst
@@ -15,6 +15,29 @@ design. If the exported addrmap contains only external components, the width
 cannot be inferred and will default to 32 bits.
 
 
+Clock and Reset
+^^^^^^^^^^^^^^^
+Where the bus decoder gets its clock and reset is selected with ``--clk-src``:
+
+``design`` (default)
+    The CPU interface carries no clock or reset. The generated module exposes
+    top-level ``clk`` and ``rst`` input ports instead, and the design is
+    responsible for distributing clock and reset to downstream slaves. The
+    decoder's datapath is purely combinational unless a register slice is
+    enabled (see ``--apb-buffer``); the ports anchor the decoder's clock
+    domain for such features.
+
+``cpuif``
+    Clock and reset are bundled with the CPU interface bus. The slave
+    interface carries the protocol-defined clock and reset (``PCLK``/``PRESETn``
+    for APB, ``ACLK``/``ARESETn`` for AXI4-Lite), and the decoder fans them out
+    to every master interface.
+
+The SystemVerilog interface definitions linked from the protocol pages declare
+``PCLK``/``PRESETn`` (``ACLK``/``ARESETn``) members. These are only driven and
+consumed by the decoder when ``--clk-src cpuif`` is selected.
+
+
 Addressing
 ^^^^^^^^^^
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,10 @@ Key command-line options:
 * ``--addr-width``: Override the slave address width
 * ``--unroll``: Unroll arrayed children into discrete interfaces
 * ``--max-decode-depth``: Control how far the decoder descends into hierarchy
+* ``--parametrize``: Propagate top-level SystemRDL parameters into the generated module
+* ``--clk-src``: Select where the decoder gets its clock and reset (``cpuif`` or ``design``, default ``design``)
+* ``--gate-signals``: Gate APB broadcast signals with each slave's select (off by default)
+* ``--apb-buffer``: Insert a register slice on the APB slave-side I/O (``none``, ``in``, ``out``, ``both``)
 
 
 Looking for VHDL?


### PR DESCRIPTION
The v0.7.0b4/b5 features (--clk-src, --gate-signals, --apb-buffer) were only covered by the `export()` docstring, which autodoc renders into the API page — the hand-written docs never mentioned them. This adds:

- **configuring.rst / index.rst** — the three new flags in the CLI option lists, plus `--parametrize`, which was already missing from both lists despite having its own docs page.
- **cpuif/introduction.rst** — a "Clock and Reset" section: `clk_src=design` default (top-level `clk`/`rst` ports, bus carries no clock/reset) vs `cpuif` mode, and a note that the downloadable interface definitions only drive `PCLK`/`PRESETn` (`ACLK`/`ARESETn`) in cpuif mode.
- **cpuif/apb.rst** — "Broadcast Signal Gating" (default-off rationale, what `--gate-signals` buys) and "Slave-Side Register Slice" (`--apb-buffer` modes, PREADY-stretching, requires `clk_src=design`).
- **cpuif/axi4lite.rst** — rewords two "tracked in issue #59" references since #59 is closed as documented.

Verified with CI's exact build (`uv run make html -C docs`): build succeeded; only pre-existing warning (api.rst literalinclude line-spec) remains. New sections confirmed present in rendered HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMyMaHGbpgrU6YvFVTjKYW