### PR TITLE
fix: restore apb3/apb4 interface import paths with deprecation shims

### DIFF
--- a/src/peakrdl_busdecoder/cpuif/apb3/apb3_interface.py
+++ b/src/peakrdl_busdecoder/cpuif/apb3/apb3_interface.py
@@ -1,0 +1,48 @@
+"""Deprecated re-export shim for API stability.
+
+The APB3/APB4 interface implementations were merged into
+``cpuif/apb/apb_interface.py``, where the protocol specifics are driven by
+class attributes on the cpuif (``apb_interface_type``, ``has_pprot``,
+``has_pstrb``). This module keeps the historical
+``cpuif.apb3.apb3_interface`` import path working; the classes below pin the
+APB3 naming the old hardwired classes used, and otherwise inherit the merged
+behavior (including ``clk_src``-conditional clock/reset ports).
+"""
+
+import warnings
+
+from ..apb.apb_interface import APBFlatInterface, APBSVInterface
+
+warnings.warn(
+    "peakrdl_busdecoder.cpuif.apb3.apb3_interface is deprecated; "
+    "use APBSVInterface/APBFlatInterface from "
+    "peakrdl_busdecoder.cpuif.apb.apb_interface instead",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class APB3SVInterface(APBSVInterface):
+    """Deprecated APB3 alias of :class:`APBSVInterface`."""
+
+    def get_interface_type(self) -> str:
+        return "apb3_intf"
+
+    def get_slave_name(self) -> str:
+        return "s_apb"
+
+    def get_master_prefix(self) -> str:
+        return "m_apb_"
+
+
+class APB3FlatInterface(APBFlatInterface):
+    """Deprecated APB3 alias of :class:`APBFlatInterface`."""
+
+    def get_slave_prefix(self) -> str:
+        return "s_apb_"
+
+    def get_master_prefix(self) -> str:
+        return "m_apb_"
+
+
+__all__ = ["APB3FlatInterface", "APB3SVInterface"]

--- a/src/peakrdl_busdecoder/cpuif/apb4/apb4_interface.py
+++ b/src/peakrdl_busdecoder/cpuif/apb4/apb4_interface.py
@@ -1,0 +1,48 @@
+"""Deprecated re-export shim for API stability.
+
+The APB3/APB4 interface implementations were merged into
+``cpuif/apb/apb_interface.py``, where the protocol specifics are driven by
+class attributes on the cpuif (``apb_interface_type``, ``has_pprot``,
+``has_pstrb``). This module keeps the historical
+``cpuif.apb4.apb4_interface`` import path working; the classes below pin the
+APB4 naming the old hardwired classes used, and otherwise inherit the merged
+behavior (including ``clk_src``-conditional clock/reset ports).
+"""
+
+import warnings
+
+from ..apb.apb_interface import APBFlatInterface, APBSVInterface
+
+warnings.warn(
+    "peakrdl_busdecoder.cpuif.apb4.apb4_interface is deprecated; "
+    "use APBSVInterface/APBFlatInterface from "
+    "peakrdl_busdecoder.cpuif.apb.apb_interface instead",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class APB4SVInterface(APBSVInterface):
+    """Deprecated APB4 alias of :class:`APBSVInterface`."""
+
+    def get_interface_type(self) -> str:
+        return "apb4_intf"
+
+    def get_slave_name(self) -> str:
+        return "s_apb"
+
+    def get_master_prefix(self) -> str:
+        return "m_apb_"
+
+
+class APB4FlatInterface(APBFlatInterface):
+    """Deprecated APB4 alias of :class:`APBFlatInterface`."""
+
+    def get_slave_prefix(self) -> str:
+        return "s_apb_"
+
+    def get_master_prefix(self) -> str:
+        return "m_apb_"
+
+
+__all__ = ["APB4FlatInterface", "APB4SVInterface"]

--- a/tests/unit/test_deprecated_imports.py
+++ b/tests/unit/test_deprecated_imports.py
@@ -1,0 +1,55 @@
+"""The pre-0.7.0b4 import paths must keep working (with a DeprecationWarning)."""
+
+import importlib
+import sys
+
+import pytest
+
+from peakrdl_busdecoder.cpuif.apb.apb_interface import APBFlatInterface, APBSVInterface
+
+_DEPRECATED_INTERFACE_MODULES = [
+    "peakrdl_busdecoder.cpuif.apb3.apb3_interface",
+    "peakrdl_busdecoder.cpuif.apb4.apb4_interface",
+]
+
+
+@pytest.mark.parametrize("module_name", _DEPRECATED_INTERFACE_MODULES)
+def test_deprecated_interface_module_warns(module_name: str) -> None:
+    sys.modules.pop(module_name, None)
+    with pytest.warns(DeprecationWarning, match="is deprecated"):
+        importlib.import_module(module_name)
+
+
+def test_apb3_interface_aliases() -> None:
+    from peakrdl_busdecoder.cpuif.apb3.apb3_interface import (
+        APB3FlatInterface,
+        APB3SVInterface,
+    )
+
+    assert issubclass(APB3SVInterface, APBSVInterface)
+    assert issubclass(APB3FlatInterface, APBFlatInterface)
+    assert APB3SVInterface.get_interface_type(object.__new__(APB3SVInterface)) == "apb3_intf"
+
+
+def test_apb4_interface_aliases() -> None:
+    from peakrdl_busdecoder.cpuif.apb4.apb4_interface import (
+        APB4FlatInterface,
+        APB4SVInterface,
+    )
+
+    assert issubclass(APB4SVInterface, APBSVInterface)
+    assert issubclass(APB4FlatInterface, APBFlatInterface)
+    assert APB4SVInterface.get_interface_type(object.__new__(APB4SVInterface)) == "apb4_intf"
+
+
+def test_cpuif_shim_paths_still_work() -> None:
+    """The silent cpuif re-export shims from #66 must also keep resolving."""
+    from peakrdl_busdecoder.cpuif.apb.apb_cpuif import APB3Cpuif as NewAPB3
+    from peakrdl_busdecoder.cpuif.apb.apb_cpuif import APB4Cpuif as NewAPB4
+    from peakrdl_busdecoder.cpuif.apb3 import APB3Cpuif
+    from peakrdl_busdecoder.cpuif.apb3.apb3_cpuif import APB3CpuifFlat  # noqa: F401
+    from peakrdl_busdecoder.cpuif.apb4 import APB4Cpuif
+    from peakrdl_busdecoder.cpuif.apb4.apb4_cpuif import APB4CpuifFlat  # noqa: F401
+
+    assert APB3Cpuif is NewAPB3
+    assert APB4Cpuif is NewAPB4


### PR DESCRIPTION
## Problem

The #66 cpuif merge kept re-export shims for the cpuif classes (`cpuif.apb3.apb3_cpuif` etc.) but deleted `cpuif/apb3/apb3_interface.py` and `cpuif/apb4/apb4_interface.py` outright — so `from peakrdl_busdecoder.cpuif.apb4.apb4_interface import APB4SVInterface` (and the APB3/Flat counterparts) broke with `ModuleNotFoundError` and no migration path.

## Fix

Recreate both modules as deprecation shims:

- Importing them emits a `DeprecationWarning` pointing at `cpuif/apb/apb_interface`.
- `APB3SVInterface`/`APB4SVInterface`/`APB3FlatInterface`/`APB4FlatInterface` are thin subclasses of the merged `APBSVInterface`/`APBFlatInterface` that pin the protocol naming the old hardwired classes used (`apb3_intf`/`apb4_intf`, `s_apb`, `m_apb_`). Port-list behavior inherits from the merged classes, so the shims stay coherent with newer features (`clk_src`-conditional clock ports, PPROT/PSTRB gating by cpuif attrs).

New `tests/unit/test_deprecated_imports.py` pins every historical import path — the interface shims must warn, and the silent cpuif shims from #66 must keep resolving to the merged classes — so future refactors can't drop them silently. Since the suite runs with `filterwarnings=error`, it also guarantees no internal code imports the deprecated modules.

## Test plan
- [x] `pytest -m "not simulation and not verilator"` — 344 passed, 1 skipped (5 new)
- [x] CI-exact `uvx ruff check .` / `uvx ruff format --check .` / `uv sync --extra cli && uvx ty check src/` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMyMaHGbpgrU6YvFVTjKYW