### PR TITLE
Make clk_src default 'off' and fix master modport clock directions (0.7.0b7)

### DIFF
--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -38,9 +38,11 @@ The following options are available on the ``peakrdl busdecoder`` command:
 * ``--max-decode-depth``: Control how far the decoder descends into hierarchy
 * ``--parametrize``: Propagate top-level SystemRDL parameters into the
   generated module (see :doc:`parameters`)
-* ``--clk-src``: Select where the decoder gets its clock and reset (``design``
-  (default) adds top-level ``clk``/``rst`` ports; ``cpuif`` bundles clock/reset
-  with the CPU interface bus)
+* ``--clk-src``: Select where the decoder gets its clock and reset (``off``
+  (default) uses no clock/reset at all — the decoder is combinational;
+  ``design`` adds top-level ``clk``/``rst`` ports that are consumed internally
+  but not fanned out; ``cpuif`` bundles clock/reset with the CPU interface bus
+  and fans them out to each master)
 * ``--gate-signals``: Gate APB broadcast signals with each slave's select so
   unselected slaves see all-zero inputs (off by default)
 * ``--apb-buffer``: Insert a single-flop register slice on the APB slave-side

--- a/docs/cpuif/apb.rst
+++ b/docs/cpuif/apb.rst
@@ -91,4 +91,4 @@ I/O:
 The APB handshake is preserved through ``PREADY``-stretching: each buffered
 direction adds one cycle to the access phase, which the protocol allows. The
 buffer flops use the design clock and reset, so this option requires
-``--clk-src design`` (the default). Non-APB CPU interfaces reject the option.
+``--clk-src design``. Non-APB CPU interfaces reject the option.

--- a/docs/cpuif/introduction.rst
+++ b/docs/cpuif/introduction.rst
@@ -19,13 +19,16 @@ Clock and Reset
 ^^^^^^^^^^^^^^^
 Where the bus decoder gets its clock and reset is selected with ``--clk-src``:
 
-``design`` (default)
+``off`` (default)
+    No clock or reset anywhere. The decoder's datapath is purely
+    combinational, so the generated module carries no clock/reset ports and
+    nothing is fanned out to the masters.
+
+``design``
     The CPU interface carries no clock or reset. The generated module exposes
-    top-level ``clk`` and ``rst`` input ports instead, and the design is
-    responsible for distributing clock and reset to downstream slaves. The
-    decoder's datapath is purely combinational unless a register slice is
-    enabled (see ``--apb-buffer``); the ports anchor the decoder's clock
-    domain for such features.
+    top-level ``clk`` and ``rst`` input ports that are consumed by clocked
+    features (see ``--apb-buffer``) but not fanned out — the design is
+    responsible for distributing clock and reset to downstream slaves.
 
 ``cpuif``
     Clock and reset are bundled with the CPU interface bus. The slave

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,7 @@ Key command-line options:
 * ``--unroll``: Unroll arrayed children into discrete interfaces
 * ``--max-decode-depth``: Control how far the decoder descends into hierarchy
 * ``--parametrize``: Propagate top-level SystemRDL parameters into the generated module
-* ``--clk-src``: Select where the decoder gets its clock and reset (``cpuif`` or ``design``, default ``design``)
+* ``--clk-src``: Select where the decoder gets its clock and reset (``off``, ``design`` or ``cpuif``, default ``off``)
 * ``--gate-signals``: Gate APB broadcast signals with each slave's select (off by default)
 * ``--apb-buffer``: Insert a register slice on the APB slave-side I/O (``none``, ``in``, ``out``, ``both``)
 

--- a/hdl-src/apb3_intf.sv
+++ b/hdl-src/apb3_intf.sv
@@ -19,8 +19,10 @@ interface apb3_intf #(
     logic PSLVERR;
 
     modport master (
-        input PCLK,
-        input PRESETn,
+        // The bus decoder forwards clock/reset downstream when generated
+        // with --clk-src cpuif, so the master side drives them.
+        output PCLK,
+        output PRESETn,
 
         output PSEL,
         output PENABLE,

--- a/hdl-src/apb4_intf.sv
+++ b/hdl-src/apb4_intf.sv
@@ -21,8 +21,10 @@ interface apb4_intf #(
     logic PSLVERR;
 
     modport master (
-        input PCLK,
-        input PRESETn,
+        // The bus decoder forwards clock/reset downstream when generated
+        // with --clk-src cpuif, so the master side drives them.
+        output PCLK,
+        output PRESETn,
 
         output PSEL,
         output PENABLE,

--- a/hdl-src/axi4lite_intf.sv
+++ b/hdl-src/axi4lite_intf.sv
@@ -30,8 +30,10 @@ interface axi4lite_intf #(
     logic [1:0] RRESP;
 
     modport master (
-        input ACLK,
-        input ARESETn,
+        // The bus decoder forwards clock/reset downstream when generated
+        // with --clk-src cpuif, so the master side drives them.
+        output ACLK,
+        output ARESETn,
 
         input AWREADY,
         output AWVALID,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "peakrdl-busdecoder"
-version = "0.7.0b6"
+version = "0.7.0b7"
 requires-python = ">=3.10"
 dependencies = [
     "jinja2~=3.1",

--- a/src/peakrdl_busdecoder/__peakrdl__.py
+++ b/src/peakrdl_busdecoder/__peakrdl__.py
@@ -137,14 +137,15 @@ class Exporter(ExporterSubcommandPlugin):
 
         arg_group.add_argument(
             "--clk-src",
-            choices=("cpuif", "design"),
-            default="design",
+            choices=("off", "cpuif", "design"),
+            default="off",
             help="""Select where the bus decoder gets its clock and reset.
-            'cpuif' bundles clk/reset with the CPU interface (slave carries
-            PCLK/PRESETn or ACLK/ARESETn, fanned out to each master).
-            'design' (default) drops clk/reset from the CPU interface and
-            exposes top-level 'clk'/'rst' ports — the design distributes
-            clock/reset to downstream slaves itself.
+            'off' (default) uses no clock or reset at all — the decoder is
+            purely combinational and nothing is fanned out. 'design' exposes
+            top-level 'clk'/'rst' ports consumed by clocked features (e.g.
+            --apb-buffer) but not fanned out to the masters. 'cpuif' bundles
+            clk/reset with the CPU interface (slave carries PCLK/PRESETn or
+            ACLK/ARESETn, fanned out to each master).
             """,
         )
 

--- a/src/peakrdl_busdecoder/design_state.py
+++ b/src/peakrdl_busdecoder/design_state.py
@@ -48,9 +48,9 @@ class DesignState:
         self.cpuif_unroll: bool = kwargs.pop("cpuif_unroll", False)
         self.parametrize: bool = kwargs.pop("parametrize", False)
         self.max_decode_depth: int = kwargs.pop("max_decode_depth", 1)
-        self.clk_src: str = kwargs.pop("clk_src", "design")
-        if self.clk_src not in ("cpuif", "design"):
-            msg.fatal(f"clk_src must be 'cpuif' or 'design', got {self.clk_src!r}")
+        self.clk_src: str = kwargs.pop("clk_src", "off")
+        if self.clk_src not in ("off", "cpuif", "design"):
+            msg.fatal(f"clk_src must be 'off', 'cpuif' or 'design', got {self.clk_src!r}")
         self.gate_signals: bool = kwargs.pop("gate_signals", False)
 
         self.apb_buffer: str = kwargs.pop("apb_buffer", "none")

--- a/src/peakrdl_busdecoder/exporter.py
+++ b/src/peakrdl_busdecoder/exporter.py
@@ -98,13 +98,17 @@ class BusDecoderExporter:
         clk_src: str
             Selects where the bus decoder gets its clock and reset.
 
+            - "off" (default): no clock or reset anywhere. The decoder is
+              purely combinational, so the module carries no clk/reset ports
+              and nothing is fanned out to the masters.
+            - "design": the CPU interface carries no clk/reset. The module
+              exposes top-level ``clk`` and ``rst`` ports consumed by clocked
+              features (e.g. ``apb_buffer``); they are not fanned out — the
+              design distributes clock/reset to downstream slaves itself.
             - "cpuif": clk/reset are bundled with the CPU interface. The slave
               bus carries the protocol-defined clock/reset (PCLK/PRESETn for
               APB, ACLK/ARESETn for AXI4-Lite) and the decoder fans them out
               to each master interface.
-            - "design" (default): the CPU interface carries no clk/reset. The
-              module exposes top-level ``clk`` and ``rst`` ports; the design
-              is responsible for distributing clock/reset to downstream slaves.
         gate_signals: bool
             Gate downstream broadcast signals with the per-slave select. For APB
             this drives PENABLE/PADDR/PWDATA/PSTRB/PPROT to '0 on unselected

--- a/tests/cocotb_lib/wrapper_gen.py
+++ b/tests/cocotb_lib/wrapper_gen.py
@@ -130,7 +130,7 @@ def generate_verilator_intf_wrapper(
     global_addr_width: int,
     global_data_width: int,
     output_dir: Path,
-    include_top_clk_rst: bool = True,
+    include_top_clk_rst: bool = False,
 ) -> Path:
     """Generate a Verilator wrapper for an interface-based bus decoder module.
 
@@ -151,8 +151,9 @@ def generate_verilator_intf_wrapper(
         Directory to write the wrapper file.
     include_top_clk_rst:
         Wire top-level ``clk``/``rst`` wrapper inputs through to the DUT.
-        Matches the exporter's default ``clk_src="design"`` mode, where the
-        module has these ports; pass False for ``clk_src="cpuif"`` DUTs.
+        Pass True only for DUTs exported with ``clk_src="design"``, which is
+        the only mode where the module has these ports; the default
+        ``clk_src="off"`` (and ``"cpuif"``) DUTs have no such ports.
 
     Returns
     -------

--- a/tests/unit/test_apb_buffer.py
+++ b/tests/unit/test_apb_buffer.py
@@ -48,7 +48,7 @@ def test_default_no_buffer_signals(simple_top: AddrmapNode, cpuif_cls: type[Base
 # apb_buffer="in"
 # ---------------------------------------------------------------------------
 def test_buffer_in_apb4_flat(simple_top: AddrmapNode) -> None:
-    content = _export_and_read(simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer="in")
+    content = _export_and_read(simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer="in", clk_src="design")
     # Input wire declarations
     for sig in ("PSEL", "PENABLE", "PWRITE", "PADDR", "PWDATA", "PPROT", "PSTRB"):
         assert f"apb_in_{sig}" in content
@@ -65,7 +65,7 @@ def test_buffer_in_apb4_flat(simple_top: AddrmapNode) -> None:
 
 def test_buffer_in_apb3_omits_pprot_pstrb(simple_top: AddrmapNode) -> None:
     """APB3 has no PPROT/PSTRB, so the buffer must skip them too."""
-    content = _export_and_read(simple_top, cpuif_cls=APB3CpuifFlat, apb_buffer="in")
+    content = _export_and_read(simple_top, cpuif_cls=APB3CpuifFlat, apb_buffer="in", clk_src="design")
     assert "apb_in_PSEL" in content
     assert "apb_in_PPROT" not in content
     assert "apb_in_PSTRB" not in content
@@ -75,7 +75,7 @@ def test_buffer_in_apb3_omits_pprot_pstrb(simple_top: AddrmapNode) -> None:
 # apb_buffer="out"
 # ---------------------------------------------------------------------------
 def test_buffer_out_apb4_flat(simple_top: AddrmapNode) -> None:
-    content = _export_and_read(simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer="out")
+    content = _export_and_read(simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer="out", clk_src="design")
     # Output wire declarations and flop block write to slave port
     for sig in ("PRDATA", "PREADY", "PSLVERR"):
         assert f"apb_out_{sig}" in content
@@ -91,7 +91,7 @@ def test_buffer_out_apb4_flat(simple_top: AddrmapNode) -> None:
 # apb_buffer="both"
 # ---------------------------------------------------------------------------
 def test_buffer_both_apb4_flat(simple_top: AddrmapNode) -> None:
-    content = _export_and_read(simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer="both")
+    content = _export_and_read(simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer="both", clk_src="design")
     assert "apb_in_PSEL" in content
     assert "apb_out_PRDATA" in content
     # Two separate always_ff blocks
@@ -103,7 +103,7 @@ def test_buffer_both_apb4_flat(simple_top: AddrmapNode) -> None:
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize("apb_buffer", ["none", "in", "out", "both"])
 def test_master_fanout_unchanged(simple_top: AddrmapNode, apb_buffer: str) -> None:
-    content = _export_and_read(simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer=apb_buffer)
+    content = _export_and_read(simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer=apb_buffer, clk_src="design")
     # Master ports always exist with protocol names regardless of buffer mode
     assert "m_apb_a_PSEL" in content
     assert "m_apb_a_PADDR" in content
@@ -113,16 +113,16 @@ def test_master_fanout_unchanged(simple_top: AddrmapNode, apb_buffer: str) -> No
 # ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
-def test_buffer_requires_clk_src_design(simple_top: AddrmapNode) -> None:
+@pytest.mark.parametrize("clk_src", [None, "off", "cpuif"])
+def test_buffer_requires_clk_src_design(simple_top: AddrmapNode, clk_src: str | None) -> None:
+    kwargs = {} if clk_src is None else {"clk_src": clk_src}
     with pytest.raises(Exception):
-        _export_and_read(
-            simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer="in", clk_src="cpuif"
-        )
+        _export_and_read(simple_top, cpuif_cls=APB4CpuifFlat, apb_buffer="in", **kwargs)
 
 
 def test_buffer_rejected_on_non_apb_cpuif(simple_top: AddrmapNode) -> None:
     with pytest.raises(Exception):
-        _export_and_read(simple_top, cpuif_cls=AXI4LiteCpuif, apb_buffer="in")
+        _export_and_read(simple_top, cpuif_cls=AXI4LiteCpuif, apb_buffer="in", clk_src="design")
 
 
 def test_invalid_apb_buffer_value(simple_top: AddrmapNode) -> None:

--- a/tests/unit/test_clk_src.py
+++ b/tests/unit/test_clk_src.py
@@ -37,7 +37,8 @@ def simple_top(compile_rdl: Callable[..., AddrmapNode]) -> AddrmapNode:
 
 
 # ---------------------------------------------------------------------------
-# clk_src=design (default): no bus clk/reset, top-level clk/rst ports added
+# clk_src=off (default): no clk/reset at all -- no bus clk/reset bundled and
+# no top-level clk/rst ports (the decoder is purely combinational)
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "cpuif_cls,clk_signal,reset_signal",
@@ -47,7 +48,7 @@ def simple_top(compile_rdl: Callable[..., AddrmapNode]) -> AddrmapNode:
         (AXI4LiteCpuifFlat, "ACLK", "ARESETn"),
     ],
 )
-def test_design_default_drops_bus_clk_reset(
+def test_off_default_drops_bus_clk_reset(
     simple_top: AddrmapNode, cpuif_cls: type[BaseCpuif], clk_signal: str, reset_signal: str
 ) -> None:
     content = _export_and_read(simple_top, cpuif_cls=cpuif_cls)
@@ -59,12 +60,44 @@ def test_design_default_drops_bus_clk_reset(
 @pytest.mark.parametrize(
     "cpuif_cls", [APB3CpuifFlat, APB4CpuifFlat, AXI4LiteCpuifFlat, APB3Cpuif, APB4Cpuif, AXI4LiteCpuif]
 )
-def test_design_adds_top_level_clk_rst_ports(
+def test_off_default_omits_top_level_clk_rst_ports(
     simple_top: AddrmapNode, cpuif_cls: type[BaseCpuif]
 ) -> None:
     content = _export_and_read(simple_top, cpuif_cls=cpuif_cls)
+    assert "input  logic clk" not in content
+    assert "input  logic rst" not in content
+
+
+# ---------------------------------------------------------------------------
+# clk_src=design: top-level clk/rst ports added, no bus clk/reset bundled
+# and nothing fanned out to the masters
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cpuif_cls", [APB3CpuifFlat, APB4CpuifFlat, AXI4LiteCpuifFlat, APB3Cpuif, APB4Cpuif, AXI4LiteCpuif]
+)
+def test_design_adds_top_level_clk_rst_ports(
+    simple_top: AddrmapNode, cpuif_cls: type[BaseCpuif]
+) -> None:
+    content = _export_and_read(simple_top, cpuif_cls=cpuif_cls, clk_src="design")
     assert "input  logic clk" in content
     assert "input  logic rst" in content
+
+
+@pytest.mark.parametrize(
+    "cpuif_cls,clk_signal,reset_signal",
+    [
+        (APB3CpuifFlat, "PCLK", "PRESETn"),
+        (APB4CpuifFlat, "PCLK", "PRESETn"),
+        (AXI4LiteCpuifFlat, "ACLK", "ARESETn"),
+    ],
+)
+def test_design_drops_bus_clk_reset(
+    simple_top: AddrmapNode, cpuif_cls: type[BaseCpuif], clk_signal: str, reset_signal: str
+) -> None:
+    content = _export_and_read(simple_top, cpuif_cls=cpuif_cls, clk_src="design")
+    for prefix in ("s_apb_", "s_axil_", "m_apb_a_", "m_apb_b_", "m_axil_a_", "m_axil_b_"):
+        assert f"{prefix}{clk_signal}" not in content
+        assert f"{prefix}{reset_signal}" not in content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_clk_src.py
+++ b/tests/unit/test_clk_src.py
@@ -1,5 +1,6 @@
 """Tests for the clk_src exporter option."""
 
+import re
 from collections.abc import Callable
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -129,6 +130,9 @@ def test_if_adds_bus_clk_reset_on_slave(
         (APB3CpuifFlat, "m_apb_a_", "PCLK", "PRESETn"),
         (APB4CpuifFlat, "m_apb_a_", "PCLK", "PRESETn"),
         (AXI4LiteCpuifFlat, "m_axil_a_", "ACLK", "ARESETn"),
+        (APB3Cpuif, "m_apb_a.", "PCLK", "PRESETn"),
+        (APB4Cpuif, "m_apb_a.", "PCLK", "PRESETn"),
+        (AXI4LiteCpuif, "m_axil_a.", "ACLK", "ARESETn"),
     ],
 )
 def test_if_drives_master_clk_reset_in_fanout(
@@ -143,6 +147,24 @@ def test_if_drives_master_clk_reset_in_fanout(
     assert f"{master_prefix}{rst}" in content
     # And fanout assignment exists
     assert f"assign {master_prefix}{clk}" in content
+
+
+@pytest.mark.parametrize(
+    "intf_file,clk,rst",
+    [
+        ("apb3_intf.sv", "PCLK", "PRESETn"),
+        ("apb4_intf.sv", "PCLK", "PRESETn"),
+        ("axi4lite_intf.sv", "ACLK", "ARESETn"),
+    ],
+)
+def test_master_modport_drives_clk_reset(intf_file: str, clk: str, rst: str) -> None:
+    """clk_src='cpuif' fanout assigns m_*.PCLK through the master modport, so
+    the shipped interface definitions must declare clock/reset as master
+    outputs -- strict simulators reject assignments to modport inputs."""
+    text = (Path(__file__).resolve().parents[2] / "hdl-src" / intf_file).read_text()
+    master = text.split("modport master")[1].split(");")[0]
+    assert re.search(rf"output\s+{clk}\b", master)
+    assert re.search(rf"output\s+{rst}\b", master)
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "peakrdl-busdecoder"
-version = "0.7.0b6"
+version = "0.7.0b7"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
# Description of change

The bus decoder datapath is purely combinational, so by default it should carry no clock or reset at all. Previously the default (`--clk-src design`) unconditionally added top-level `clk`/`rst` ports that nothing consumed unless `--apb-buffer` was enabled.

`--clk-src` now has three modes:

- **`off` (new default)**: no clock/reset ports anywhere and nothing fanned out — the module is fully combinational.
- **`design`**: top-level `clk`/`rst` input ports consumed by clocked features (e.g. `--apb-buffer`) but not fanned out to the masters.
- **`cpuif`**: unchanged — PCLK/PRESETn (ACLK/ARESETn) bundled with the slave interface and fanned out to every master.

Also fixes a defect found while differentially auditing generated RTL between 0.7.0b3 and HEAD: with `--clk-src cpuif` and an SV-interface cpuif, the fanout emits `assign m_apb_x.PCLK = ...`, but the shipped `hdl-src` interface definitions declared clock/reset as master-modport *inputs* — assigning to an input-direction modport member is illegal and strict simulators reject the module. PCLK/PRESETn (ACLK/ARESETn) are now master-modport outputs, since the decoder is the clock forwarder in this mode; the slave modport still receives them as inputs.

The audit covered 270 generated configurations (9 designs × 6 cpuifs × 5 option sets) plus a source-level review of the full 0.7.0b3..HEAD range; every other output difference traced to intentional fixes. Note this PR is a **breaking default change**: integrations relying on the implicit `clk`/`rst` ports must now pass `--clk-src design` explicitly.

# Checklist

- [x] I have reviewed this project's [contribution guidelines](https://github.com/arnavsacheti/PeakRDL-BusDecoder/blob/main/CONTRIBUTING.md)
- [x] This change has been tested and does not break any of the existing unit tests. (361 passed, 1 skipped; cocotb simulation tests not run locally — no Verilator in the environment)
- [x] If this change adds new features, I have added new unit tests that cover them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyoEmVCWFJHNtx3kVS3F6s